### PR TITLE
ecdsa v0.16.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 [[package]]
 name = "sp1-lib"
 version = "1.0.1"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=john/lib-refactor#d412a24c036e346b11384308e1f8c6f638782515"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -52,12 +52,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cfg-if"
@@ -67,24 +64,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -104,16 +101,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -132,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -172,17 +168,6 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
-dependencies = [
- "der",
- "elliptic-curve",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 dependencies = [
  "anyhow",
@@ -197,6 +182,17 @@ dependencies = [
  "signature",
  "sp1-lib",
  "spki",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
 ]
 
 [[package]]
@@ -227,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -254,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -286,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.4"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "generic-array"
@@ -303,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -340,18 +336,18 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -378,19 +374,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -399,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -412,7 +407,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.8",
+ "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve",
 ]
 
@@ -422,7 +417,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
- "ecdsa 0.16.8",
+ "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "elliptic-curve",
  "primeorder",
 ]
@@ -447,16 +442,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "platforms"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
-
-[[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+dependencies = [
+ "zerocopy",
+ "zerocopy-derive",
+]
 
 [[package]]
 name = "primeorder"
@@ -527,14 +520,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys",
 ]
@@ -545,7 +539,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccce7bae150b815f0811db41b8312fcb74bffa4cab9cee5429ee00f356dd5bd4"
 dependencies = [
- "ecdsa 0.16.8",
+ "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array",
  "p256",
@@ -581,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -596,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -648,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
@@ -658,14 +652,14 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sp1-lib"
 version = "1.0.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=john/lib-refactor#d412a24c036e346b11384308e1f8c6f638782515"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=john/lib-refactor#f7c4e66d2230a9907fadf617ef7f2a4cd9eccfa3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -675,21 +669,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -697,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -732,9 +720,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -744,22 +732,23 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -768,48 +757,75 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a3946ecfc929b583800f4629b6c25b88ac6e92a40ea5670f77112a85d40a8b"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,12 +443,11 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
 dependencies = [
  "zerocopy",
- "zerocopy-derive",
 ]
 
 [[package]]
@@ -658,8 +657,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sp1-lib"
-version = "1.0.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=john/lib-refactor#f7c4e66d2230a9907fadf617ef7f2a4cd9eccfa3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4c2cc40e1019faac8cdbe61172c7be09960cfe240c712be46df3795c53fce8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -805,9 +805,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +185,8 @@ dependencies = [
 name = "ecdsa"
 version = "0.16.9"
 dependencies = [
+ "anyhow",
+ "cfg-if",
  "der",
  "digest",
  "elliptic-curve",
@@ -187,6 +195,7 @@ dependencies = [
  "serdect",
  "sha2",
  "signature",
+ "sp1-lib",
  "spki",
 ]
 
@@ -460,18 +469,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -578,9 +587,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -596,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -654,6 +663,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
+name = "sp1-lib"
+version = "1.0.1"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "serde",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,9 +702,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,12 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +171,6 @@ name = "ecdsa"
 version = "0.16.9"
 dependencies = [
  "anyhow",
- "bit-vec",
  "cfg-if",
  "der",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +177,7 @@ name = "ecdsa"
 version = "0.16.9"
 dependencies = [
  "anyhow",
+ "bit-vec",
  "cfg-if",
  "der",
  "digest",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -38,7 +38,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["dev"
 sha2 = { version = "0.10", default-features = false }
 
 [features]
-default = ["digest", "verifying"]
+default = ["digest"]
 alloc = ["elliptic-curve/alloc", "signature/alloc", "spki/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -29,7 +29,7 @@ spki = { version = "0.7.2", optional = true, default-features = false }
 cfg-if = "1.0"
 hex-literal = "0.4"
 
-# [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
+[target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "john/lib-refactor" }
 anyhow = "1.0"
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0"
 hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
-sp1-lib = "^1.1.0"
+sp1-lib = "^1.1.0,1.2.0-0"
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -29,7 +29,7 @@ spki = { version = "0.7.2", optional = true, default-features = false }
 cfg-if = "1.0"
 hex-literal = "0.4"
 
-[target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
+# [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "john/lib-refactor" }
 anyhow = "1.0"
 
@@ -38,7 +38,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["dev"
 sha2 = { version = "0.10", default-features = false }
 
 [features]
-default = ["digest"]
+default = ["digest", "verifying"]
 alloc = ["elliptic-curve/alloc", "signature/alloc", "spki/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -26,10 +26,15 @@ rfc6979 = { version = "0.4", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.7.2", optional = true, default-features = false }
+cfg-if = "1.0"
+hex-literal = "0.4"
+
+[target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
+sp1-lib = { path = "../../../vm/sp1/zkvm/lib" }
+anyhow = "1.0"
 
 [dev-dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["dev"] }
-hex-literal = "0.4"
 sha2 = { version = "0.10", default-features = false }
 
 [features]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0"
 hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
-sp1-lib = { path = "../../../vm/sp1/zkvm/lib" }
+sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "john/lib-refactor" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0"
 hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
-sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "john/lib-refactor" }
+sp1-lib = "^1.1.0"
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -32,7 +32,6 @@ hex-literal = "0.4"
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "john/lib-refactor" }
 anyhow = "1.0"
-bit-vec = "0.8"
 
 [dev-dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["dev"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -38,7 +38,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["dev"
 sha2 = { version = "0.10", default-features = false }
 
 [features]
-default = ["digest"]
+default = ["digest", "verifying"]
 alloc = ["elliptic-curve/alloc", "signature/alloc", "spki/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -32,6 +32,7 @@ hex-literal = "0.4"
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "john/lib-refactor" }
 anyhow = "1.0"
+bit-vec = "0.8"
 
 [dev-dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["dev"] }

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,11 +1,11 @@
-#![no_std]
+// #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![warn(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -70,6 +70,9 @@ pub mod hazmat;
 mod signing;
 #[cfg(feature = "verifying")]
 mod verifying;
+
+#[cfg(all(target_os = "zkvm", target_vendor = "succinct"))]
+mod sp1;
 
 pub use crate::{normalized::NormalizedSignature, recovery::RecoveryId};
 

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -300,13 +300,13 @@ where
                 // Reference: https://en.bitcoin.it/wiki/Secp256k1.
                 const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
 
-                // TODO: Add a check for field bytes size? (ex. <C as Curve>::FieldBytesSize::USIZE == 32)
+                // Note: An additional check can be added to ensure the field bytes size is 32 bytes, but this is not neceessary.
                 if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) && prehash.len() == 32 {
                     return Self::recover_from_prehash_secp256k1(prehash, signature, recovery_id);
                 }
             }
         }
-        
+
         let (r, s) = signature.split_scalars();
         let z = <Scalar<C> as Reduce<C::Uint>>::reduce_bytes(&bits2field::<C>(prehash)?);
 

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -35,7 +35,6 @@ where
     ///
     /// This function is only enabled inside of SP1 programs, and accelerates the
     /// recovery process using SP1 syscalls for secp256k1.
-    #[allow(non_snake_case)]
     pub fn recover_from_prehash_secp256k1(
         prehash: &[u8],
         signature: &Signature<C>,

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -1,6 +1,5 @@
 use crate::{Error, RecoveryId, Result};
 use digest::generic_array::ArrayLength;
-use elliptic_curve::ops::Invert;
 use elliptic_curve::PrimeField;
 use elliptic_curve::{
     point::DecompressPoint,
@@ -34,27 +33,28 @@ where
     /// signature over that prehashed message, and a [`RecoveryId`].
     ///
     /// This function is only enabled inside of SP1 programs, and accelerates the
-    /// recovery process using SP1 syscalls for secp256k1.
+    /// recovery process using SP1 syscalls for secp256k1. Verifies the signature
+    /// is correct against the supplied pubkey.
     pub fn recover_from_prehash_secp256k1(
         prehash: &[u8],
         signature: &Signature<C>,
         recovery_id: RecoveryId,
     ) -> Result<Self> {
+        // Recover the signature bytes and the recovery id from the signature.
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..64].copy_from_slice(&signature.to_bytes());
         sig_bytes[64] = recovery_id.to_byte();
-        let (compressed_pubkey, s_inv) = Self::unconstrained_ecrecover(
-            sig_bytes.as_slice().try_into().unwrap(),
-            prehash.try_into().unwrap(),
-        );
+        let (compressed_pubkey, s_inv) =
+            recover_ecdsa_unconstrained(&sig_bytes, prehash.try_into().unwrap());
+        let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv).unwrap()).unwrap();
 
-        let pubkey = Self::decompress_pubkey(&compressed_pubkey)?;
+        let pubkey = decompress_pubkey(&compressed_pubkey)?;
 
-        let verified = Self::verify_signature(
+        let verified = Self::verify_signature_secp256k1(
             &pubkey,
             &prehash.try_into().unwrap(),
             &Signature::from_slice(&sig_bytes[..64]).unwrap(),
-            Some(&s_inv),
+            &s_inverse,
         );
 
         if verified {
@@ -65,13 +65,12 @@ where
     }
 
     /// Convert a scalar to its little endian bit representation.
-    /// TODO: Can we derive bits from the scalar type?
     fn scalar_to_little_endian_bits<const NUM_BITS: usize>(scalar: &Scalar<C>) -> [bool; NUM_BITS] {
         // Convert the scalar to its byte representation
         let mut bytes = scalar.to_repr();
         bytes.reverse();
 
-        // Create a vector to hold the bits
+        // Create an array to hold the bits
         let mut bits = [false; NUM_BITS];
 
         // Iterate over each byte
@@ -85,38 +84,32 @@ where
         bits
     }
 
-    /// Verify a signature over a message hash using SP1 acceleration.
-    pub fn verify_signature(
+    /// Verify the prehashed message against the provided ECDSA signature.
+    ///
+    /// Accepts the following arguments:
+    /// - `pubkey`: The public key to verify the signature against.
+    /// - `msg_hash`: The prehashed message to verify the signature against.
+    /// - `signature`: The signature to verify.
+    /// - `s_inverse`: The inverse of the scalar `s` in the signature.
+    ///
+    /// This function is a modified version of [`crate::hazmat::verify_prehashed`] with
+    /// changes implemented to support SP1 acceleration.
+    pub fn verify_signature_secp256k1(
         pubkey: &[u8; 65],
         msg_hash: &[u8; 32],
         signature: &Signature<C>,
-        s_inverse: Option<&Scalar<C>>,
+        s_inverse: &Scalar<C>,
     ) -> bool {
-        // Convert the pubkey into a Secp256k1AffinePoint.
-        let pubkey_x: Scalar<C> =
-            Scalar::<C>::from_repr(bits2field::<C>(&pubkey[1..33]).unwrap()).unwrap();
-        let pubkey_y: Scalar<C> =
-            Scalar::<C>::from_repr(bits2field::<C>(&pubkey[33..]).unwrap()).unwrap();
-        let mut pubkey_x_le_bytes = pubkey_x.to_repr();
+        let mut pubkey_x_le_bytes = pubkey[1..33].to_vec();
         pubkey_x_le_bytes.reverse();
-        let mut pubkey_y_le_bytes = pubkey_y.to_repr();
+        let mut pubkey_y_le_bytes = pubkey[33..].to_vec();
         pubkey_y_le_bytes.reverse();
         let affine =
             Secp256k1AffinePoint::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat());
 
         // Split the signature into its two scalars.
         let (r, s) = signature.split_scalars();
-        let computed_s_inv;
-        let s_inv = match s_inverse {
-            Some(s_inv) => {
-                assert_eq!(*s_inv * s.as_ref(), Scalar::<C>::ONE);
-                s_inv
-            }
-            None => {
-                computed_s_inv = s.invert();
-                &computed_s_inv
-            }
-        };
+        assert_eq!(*s_inverse * s.as_ref(), Scalar::<C>::ONE);
 
         // Convert the message hash into a scalar.
         let field = bits2field::<C>(msg_hash);
@@ -127,10 +120,10 @@ where
         let z = field;
 
         // Compute the two scalars.
-        let u1 = z * s_inv;
-        let u2 = *r * s_inv;
+        let u1 = z * s_inverse;
+        let u2 = *r * s_inverse;
 
-        // Convert u1 and u2 to little endian bits for the MSM.
+        // Convert u1 and u2 to little endian bits for the MSM. Then, compute the MSM.
         let u1_le_bits = Self::scalar_to_little_endian_bits::<256>(&u1);
         let u2_le_bits = Self::scalar_to_little_endian_bits::<256>(&u2);
         let res = Secp256k1AffinePoint::multi_scalar_multiplication(
@@ -153,48 +146,57 @@ where
         }
         *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
     }
+}
 
-    /// Outside of the VM, computes the pubkey and s_inverse value from a signature and a message hash.
-    ///
-    /// WARNING: The values are read from outside of the VM and are not constrained to be correct.
-    /// Either use `decompress_pubkey` and `verify_signature` to verify the results of this function, or
-    /// use `ecrecover`.
-    pub fn unconstrained_ecrecover(sig: &[u8; 65], msg_hash: &[u8; 32]) -> ([u8; 33], Scalar<C>) {
-        // The `unconstrained!` wrapper is used since none of these computations directly affect
-        // the output values of the VM. The remainder of the function sets the constraints on the values
-        // instead. Removing the `unconstrained!` wrapper slightly increases the cycle count.
-        unconstrained! {
-            let mut buf = [0; 65 + 32];
-            let (buf_sig, buf_msg_hash) = buf.split_at_mut(sig.len());
-            buf_sig.copy_from_slice(sig);
-            buf_msg_hash.copy_from_slice(msg_hash);
-            io::write(FD_ECRECOVER_HOOK, &buf);
-        }
-
-        let recovered_bytes: [u8; 33] = io::read_vec().try_into().unwrap();
-
-        let s_inv_bytes: [u8; 32] = io::read_vec().try_into().unwrap();
-        let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv_bytes).unwrap()).unwrap();
-
-        (recovered_bytes, s_inverse)
+/// Outside of the VM, computes the pubkey and s_inverse value from a signature and a message hash.
+///
+/// WARNING: The values are read from outside of the VM and are not constrained to be correct. Use
+/// [`VerifyingKey::recover_from_prehash_secp256k1`] to securely recover the public key associated with
+/// a signature and message hash.
+fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32]) -> ([u8; 33], [u8; 32]) {
+    // The `unconstrained!` wrapper is used to not include the cycles used to get the "hint" for the compressed
+    // public key and s_inverse values from a non-zkVM context, because the values will be constrained
+    // in the VM.
+    unconstrained! {
+        let mut buf = [0; 65 + 32];
+        let (buf_sig, buf_msg_hash) = buf.split_at_mut(sig.len());
+        buf_sig.copy_from_slice(sig);
+        buf_msg_hash.copy_from_slice(msg_hash);
+        io::write(FD_ECRECOVER_HOOK, &buf);
     }
 
-    /// Convert a compressed pubkey into decompressed form using SP1 acceleration.
-    pub fn decompress_pubkey(compressed_pubkey: &[u8; 33]) -> Result<[u8; 65]> {
-        let mut decompressed_key: [u8; 64] = [0; 64];
-        decompressed_key[..32].copy_from_slice(&compressed_pubkey[1..]);
-        let is_odd = match compressed_pubkey[0] {
-            2 => false,
-            3 => true,
-            _ => return Err(Error::new()),
-        };
-        unsafe {
-            syscall_secp256k1_decompress(&mut decompressed_key, is_odd);
-        }
+    let recovered_bytes: [u8; 33] = io::read_vec().try_into().unwrap();
+    let s_inv_bytes: [u8; 32] = io::read_vec().try_into().unwrap();
 
-        let mut result: [u8; 65] = [0; 65];
-        result[0] = 4;
-        result[1..].copy_from_slice(&decompressed_key);
-        Ok(result)
+    (recovered_bytes, s_inv_bytes)
+}
+
+/// Takes in a compressed public key and decompresses it using the SP1 syscall `syscall_secp256k1_decompress`.
+///
+/// The first byte of the compressed public key is 0x02 if the y coordinate is even, 0x03 if the y coordinate is odd,
+/// and the remaining 32 bytes are the x coordinate of the decompressed pubkey.
+///
+/// The decompressed public key is 65 bytes long, with 0x04 as the first byte,
+/// and the remaining 64 bytes being the x and y coordinates of the decompressed pubkey.
+///
+/// More details on secp256k1 public key format can be found in the [Bitcoin wiki](https://en.bitcoin.it/wiki/Protocol_documentation#Signatures).
+///
+/// SAFETY: Our syscall will check that the x and y coordinates are within the
+/// secp256k1 scalar field.
+pub fn decompress_pubkey(compressed_pubkey: &[u8; 33]) -> Result<[u8; 65]> {
+    let mut decompressed_key: [u8; 64] = [0; 64];
+    decompressed_key[..32].copy_from_slice(&compressed_pubkey[1..]);
+    let is_odd = match compressed_pubkey[0] {
+        2 => false,
+        3 => true,
+        _ => return Err(Error::new()),
+    };
+    unsafe {
+        syscall_secp256k1_decompress(&mut decompressed_key, is_odd);
     }
+
+    let mut result: [u8; 65] = [0; 65];
+    result[0] = 4;
+    result[1..].copy_from_slice(&decompressed_key);
+    Ok(result)
 }

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -1,0 +1,201 @@
+use crate::{Error, RecoveryId, Result};
+use digest::generic_array::ArrayLength;
+use elliptic_curve::ops::Invert;
+use elliptic_curve::PrimeField;
+use elliptic_curve::{
+    point::DecompressPoint,
+    sec1::{self, FromEncodedPoint, ToEncodedPoint},
+    AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, Scalar,
+};
+
+use elliptic_curve::Field;
+use sp1_lib::io::{self, FD_ECRECOVER_HOOK};
+use sp1_lib::unconstrained;
+use sp1_lib::{
+    secp256k1::Secp256k1AffinePoint, syscall_secp256k1_decompress,
+    utils::AffinePoint as Sp1AffinePoint,
+};
+
+use crate::{
+    hazmat::{bits2field, VerifyPrimitive},
+    Signature, SignatureSize, VerifyingKey,
+};
+
+#[cfg(feature = "verifying")]
+impl<C> VerifyingKey<C>
+where
+    C: PrimeCurve + CurveArithmetic,
+    AffinePoint<C>:
+        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    /// Recover a [`VerifyingKey`] from the given `prehash` of a message, the
+    /// signature over that prehashed message, and a [`RecoveryId`].
+    ///
+    /// This function is only enabled inside of SP1 programs, and accelerates the
+    /// recovery process using SP1 syscalls for secp256k1.
+    #[allow(non_snake_case)]
+    pub fn recover_from_prehash_secp256k1(
+        prehash: &[u8],
+        signature: &Signature<C>,
+        recovery_id: RecoveryId,
+    ) -> Result<Self> {
+        let mut sig_bytes = [0u8; 65];
+        sig_bytes[..64].copy_from_slice(&signature.to_bytes());
+        sig_bytes[64] = recovery_id.to_byte();
+        let (compressed_pubkey, s_inv) = Self::unconstrained_ecrecover(
+            sig_bytes.as_slice().try_into().unwrap(),
+            prehash.try_into().unwrap(),
+        );
+
+        let pubkey = Self::decompress_pubkey(&compressed_pubkey)?;
+
+        let verified = Self::verify_signature(
+            &pubkey,
+            &prehash.try_into().unwrap(),
+            &Signature::from_slice(&sig_bytes[..64]).unwrap(),
+            Some(&s_inv),
+        );
+
+        if verified {
+            VerifyingKey::from_sec1_bytes(&pubkey).map_err(|_| Error::new())
+        } else {
+            Err(Error::new())
+        }
+    }
+
+    /// Convert a scalar to its little endian bit representation.
+    /// TODO: Can we derive bits from the scalar type?
+    fn scalar_to_little_endian_bits<const NUM_BITS: usize>(scalar: &Scalar<C>) -> [bool; NUM_BITS] {
+        // Convert the scalar to its byte representation
+        let mut bytes = scalar.to_repr();
+        bytes.reverse();
+
+        // Create a vector to hold the bits
+        let mut bits = [false; NUM_BITS];
+
+        // Iterate over each byte
+        for (byte_index, byte) in bytes.iter().enumerate() {
+            // Convert each byte to its bits in little endian order
+            for bit_index in 0..8 {
+                bits[byte_index * 8 + bit_index] = ((byte >> bit_index) & 1) == 1;
+            }
+        }
+
+        bits
+    }
+
+    /// Verify a signature over a message hash using SP1 acceleration.
+    pub fn verify_signature(
+        pubkey: &[u8; 65],
+        msg_hash: &[u8; 32],
+        signature: &Signature<C>,
+        s_inverse: Option<&Scalar<C>>,
+    ) -> bool {
+        // Convert the pubkey into a Secp256k1AffinePoint.
+        let pubkey_x: Scalar<C> =
+            Scalar::<C>::from_repr(bits2field::<C>(&pubkey[1..33]).unwrap()).unwrap();
+        let pubkey_y: Scalar<C> =
+            Scalar::<C>::from_repr(bits2field::<C>(&pubkey[33..]).unwrap()).unwrap();
+        let mut pubkey_x_le_bytes = pubkey_x.to_repr();
+        pubkey_x_le_bytes.reverse();
+        let mut pubkey_y_le_bytes = pubkey_y.to_repr();
+        pubkey_y_le_bytes.reverse();
+        let affine =
+            Secp256k1AffinePoint::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat());
+
+        // Split the signature into its two scalars.
+        let (r, s) = signature.split_scalars();
+        let computed_s_inv;
+        let s_inv = match s_inverse {
+            Some(s_inv) => {
+                assert_eq!(*s_inv * s.as_ref(), Scalar::<C>::ONE);
+                s_inv
+            }
+            None => {
+                computed_s_inv = s.invert();
+                &computed_s_inv
+            }
+        };
+
+        // Convert the message hash into a scalar.
+        let field = bits2field::<C>(msg_hash);
+        if field.is_err() {
+            return false;
+        }
+        let field: Scalar<C> = Scalar::<C>::from_repr(field.unwrap()).unwrap();
+        let z = field;
+
+        // Compute the two scalars.
+        let u1 = z * s_inv;
+        let u2 = *r * s_inv;
+
+        // Convert u1 and u2 to little endian bits for the MSM.
+        let u1_le_bits = Self::scalar_to_little_endian_bits::<256>(&u1);
+        let u2_le_bits = Self::scalar_to_little_endian_bits::<256>(&u2);
+        let res = Secp256k1AffinePoint::multi_scalar_multiplication(
+            &u1_le_bits,
+            Secp256k1AffinePoint(Secp256k1AffinePoint::GENERATOR),
+            &u2_le_bits,
+            affine,
+        )
+        .unwrap();
+
+        // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+        let mut x_bytes_be = [0u8; 32];
+        for i in 0..8 {
+            x_bytes_be[i * 4..(i * 4) + 4].copy_from_slice(&res.0[i].to_le_bytes());
+        }
+        x_bytes_be.reverse();
+        let x_field = bits2field::<C>(&x_bytes_be);
+        if x_field.is_err() {
+            return false;
+        }
+        *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
+    }
+
+    /// Outside of the VM, computes the pubkey and s_inverse value from a signature and a message hash.
+    ///
+    /// WARNING: The values are read from outside of the VM and are not constrained to be correct.
+    /// Either use `decompress_pubkey` and `verify_signature` to verify the results of this function, or
+    /// use `ecrecover`.
+    pub fn unconstrained_ecrecover(sig: &[u8; 65], msg_hash: &[u8; 32]) -> ([u8; 33], Scalar<C>) {
+        // The `unconstrained!` wrapper is used since none of these computations directly affect
+        // the output values of the VM. The remainder of the function sets the constraints on the values
+        // instead. Removing the `unconstrained!` wrapper slightly increases the cycle count.
+        unconstrained! {
+            let mut buf = [0; 65 + 32];
+            let (buf_sig, buf_msg_hash) = buf.split_at_mut(sig.len());
+            buf_sig.copy_from_slice(sig);
+            buf_msg_hash.copy_from_slice(msg_hash);
+            io::write(FD_ECRECOVER_HOOK, &buf);
+        }
+
+        let recovered_bytes: [u8; 33] = io::read_vec().try_into().unwrap();
+
+        let s_inv_bytes: [u8; 32] = io::read_vec().try_into().unwrap();
+        let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv_bytes).unwrap()).unwrap();
+
+        (recovered_bytes, s_inverse)
+    }
+
+    /// Convert a compressed pubkey into decompressed form using SP1 acceleration.
+    pub fn decompress_pubkey(compressed_pubkey: &[u8; 33]) -> Result<[u8; 65]> {
+        let mut decompressed_key: [u8; 64] = [0; 64];
+        decompressed_key[..32].copy_from_slice(&compressed_pubkey[1..]);
+        let is_odd = match compressed_pubkey[0] {
+            2 => false,
+            3 => true,
+            _ => return Err(Error::new()),
+        };
+        unsafe {
+            syscall_secp256k1_decompress(&mut decompressed_key, is_odd);
+        }
+
+        let mut result: [u8; 65] = [0; 65];
+        result[0] = 4;
+        result[1..].copy_from_slice(&decompressed_key);
+        Ok(result)
+    }
+}

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -33,8 +33,7 @@ where
     /// signature over that prehashed message, and a [`RecoveryId`].
     ///
     /// This function leverages SP1 syscalls for secp256k1 to accelerate public key recovery
-    /// in the zkVM. After recovery, it verifies the signature against the recovered public key
-    /// to ensure correctness.
+    /// in the zkVM. Verifies the signature against the recovered public key to ensure correctness.
     pub fn recover_from_prehash_secp256k1(
         prehash: &[u8],
         signature: &Signature<C>,

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -109,8 +109,8 @@ where
         let (mut u1_le_bytes, mut u2_le_bytes) = (u1.to_repr(), u2.to_repr());
         u1_le_bytes.reverse();
         u2_le_bytes.reverse();
-        let u1_le_bits = bytes_to_bits(u1_le_bytes.as_slice().try_into().unwrap());
-        let u2_le_bits = bytes_to_bits(u2_le_bytes.as_slice().try_into().unwrap());
+        let u1_le_bits = bytes_to_le_bits(u1_le_bytes.as_slice().try_into().unwrap());
+        let u2_le_bits = bytes_to_le_bits(u2_le_bytes.as_slice().try_into().unwrap());
 
         // Compute the MSM.
         let res = Secp256k1AffinePoint::multi_scalar_multiplication(
@@ -134,15 +134,10 @@ where
     }
 }
 
-/// Convert bytes to bits. Used to convert the scalar values to little endian bits for the MSM.
-fn bytes_to_bits(bytes: &[u8; 32]) -> [bool; 256] {
-    // let bits = bit_vec::BitVec::from_bytes(bytes);
-    // let mut bool_array = [false; 256];
-    // for (i, bit) in bits.iter().enumerate() {
-    //     bool_array[i] = bit;
-    // }
-    // bool_array
+/// Convert bytes to LE bits. Used to convert the scalar values to little endian bits for the MSM.
+fn bytes_to_le_bits(bytes: &[u8; 32]) -> [bool; 256] {
     let mut bits = [false; 256];
+    // Flip the bit order in each byte.
     for (i, &byte) in bytes.iter().enumerate() {
         for j in 0..8 {
             bits[i * 8 + j] = ((byte >> j) & 1) == 1;

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -136,12 +136,19 @@ where
 
 /// Convert bytes to bits. Used to convert the scalar values to little endian bits for the MSM.
 fn bytes_to_bits(bytes: &[u8; 32]) -> [bool; 256] {
-    let bits = bit_vec::BitVec::from_bytes(bytes);
-    let mut bool_array = [false; 256];
-    for (i, bit) in bits.iter().enumerate() {
-        bool_array[i] = bit;
+    // let bits = bit_vec::BitVec::from_bytes(bytes);
+    // let mut bool_array = [false; 256];
+    // for (i, bit) in bits.iter().enumerate() {
+    //     bool_array[i] = bit;
+    // }
+    // bool_array
+    let mut bits = [false; 256];
+    for (i, &byte) in bytes.iter().enumerate() {
+        for j in 0..8 {
+            bits[i * 8 + j] = ((byte >> j) & 1) == 1;
+        }
     }
-    bool_array
+    bits
 }
 
 /// Outside of the VM, computes the pubkey and s_inverse value from a signature and a message hash.

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -135,15 +135,13 @@ where
 }
 
 /// Convert bytes to bits. Used to convert the scalar values to little endian bits for the MSM.
-/// TODO: See if we can use bytemuck.
 fn bytes_to_bits(bytes: &[u8; 32]) -> [bool; 256] {
-    let mut bits = [false; 256];
-    for (i, &byte) in bytes.iter().enumerate() {
-        for j in 0..8 {
-            bits[i * 8 + j] = ((byte >> j) & 1) == 1;
-        }
+    let bits = bit_vec::BitVec::from_bytes(bytes);
+    let mut bool_array = [false; 256];
+    for (i, bit) in bits.iter().enumerate() {
+        bool_array[i] = bit;
     }
-    bits
+    bool_array
 }
 
 /// Outside of the VM, computes the pubkey and s_inverse value from a signature and a message hash.


### PR DESCRIPTION
## Overview
Patch the `ecdsa-core` crate to use SP1 acceleration for ECDSA recovery. Specifically, patch the `recover_from_prehash` function, which is the entrypoint for most functions in https://github.com/alloy-rs/core that reference this crate.

When applied, this patch accelerates ECDSA recovery in downstream crates such as `k256`. It can also be used directly in `rust-secp256k1`.

## Details
- Add an SP1 module that hosts the SP1 acceleration logic.
- Route to the SP1 acceleration when in zkVM mode when `recover_from_prehash` is invoked for a secp256k1 ecrecover.

TODO: Move to a new SP1 release once https://github.com/succinctlabs/sp1/pull/1189 is included.