### PR TITLE
feat: included secp256r1 in recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -187,6 +187,7 @@ dependencies = [
  "serdect",
  "sha2",
  "signature",
+ "sp1-derive",
  "sp1-lib",
  "spki",
 ]
@@ -625,7 +626,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -677,9 +678,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "sp1-derive"
+version = "3.0.0-rc4"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#9af1686c3a07bfe2edd0119b8cb2175729f467fe"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sp1-lib"
-version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#1dec7e97cc34075063221731470479ef2fdb4ff0"
+version = "3.0.0-rc4"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#9af1686c3a07bfe2edd0119b8cb2175729f467fe"
 dependencies = [
  "bincode",
  "serde",
@@ -712,6 +722,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -776,7 +797,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -798,7 +819,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -859,7 +880,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn",
 ]
 
 [[package]]
@@ -190,7 +190,6 @@ dependencies = [
  "serdect",
  "sha2",
  "signature",
- "sp1-derive",
  "sp1-lib",
  "spki",
 ]
@@ -629,7 +628,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn",
 ]
 
 [[package]]
@@ -687,15 +686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "sp1-derive"
-version = "3.0.0-rc4"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#9af1686c3a07bfe2edd0119b8cb2175729f467fe"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "sp1-lib"
 version = "3.0.0-rc4"
 source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#9af1686c3a07bfe2edd0119b8cb2175729f467fe"
@@ -731,17 +721,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -806,7 +785,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -828,7 +807,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -889,7 +868,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base16ct"
@@ -58,9 +58,12 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -76,9 +79,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -130,7 +133,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -331,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -349,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -413,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "p256"
@@ -465,9 +468,9 @@ checksum = "0e4c7666f2019727f9e8e14bf14456e99c707d780922869f1ba473eee101fa49"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
 ]
@@ -483,18 +486,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -572,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -602,9 +605,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -620,13 +623,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -660,6 +663,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
@@ -736,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,9 +762,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "untrusted"
@@ -777,9 +786,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -788,24 +797,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -813,28 +822,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -864,9 +873,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -874,13 +883,13 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -187,6 +187,7 @@ dependencies = [
  "serdect",
  "sha2",
  "signature",
+ "sp1-derive",
  "sp1-lib",
  "spki",
 ]
@@ -625,7 +626,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -677,9 +678,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "sp1-derive"
+version = "2.0.0"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#1dec7e97cc34075063221731470479ef2fdb4ff0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sp1-lib"
 version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#e1c55209d0eeb850d69fbe58b6623da9ec778e71"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#1dec7e97cc34075063221731470479ef2fdb4ff0"
 dependencies = [
  "bincode",
  "serde",
@@ -712,6 +723,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -776,7 +798,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -798,7 +820,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -859,7 +881,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -187,7 +187,6 @@ dependencies = [
  "serdect",
  "sha2",
  "signature",
- "sp1-derive",
  "sp1-lib",
  "spki",
 ]
@@ -626,7 +625,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -678,16 +677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "sp1-derive"
-version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#1dec7e97cc34075063221731470479ef2fdb4ff0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "sp1-lib"
 version = "2.0.0"
 source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#1dec7e97cc34075063221731470479ef2fdb4ff0"
@@ -723,17 +712,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -798,7 +776,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -820,7 +798,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -881,7 +859,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,8 +687,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sp1-lib"
-version = "3.0.0-rc4"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#9af1686c3a07bfe2edd0119b8cb2175729f467fe"
+version = "3.0.0"
+source = "git+https://github.com/succinctlabs/sp1.git?rev=e443fc9ca17edbfffb8af8a6d3834659739f7705#e443fc9ca17edbfffb8af8a6d3834659739f7705"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "sp1-lib"
 version = "2.0.0"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=tamir/v1.3.0-rc2#a8db6b19673ed7f5bf7007faff1d2ef177713e3b"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=secp256r1#e1c55209d0eeb850d69fbe58b6623da9ec778e71"
 dependencies = [
  "bincode",
  "serde",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0"
 hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
-sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "secp256r1" }
+sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", rev = "e443fc9ca17edbfffb8af8a6d3834659739f7705" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -31,7 +31,6 @@ hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "secp256r1" }
-sp1-derive = { git = "https://github.com/succinctlabs/sp1.git", branch = "secp256r1" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -31,6 +31,7 @@ hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "secp256r1" }
+sp1-derive = { git = "https://github.com/succinctlabs/sp1.git", branch = "secp256r1" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -39,7 +39,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["dev"
 sha2 = { version = "0.10", default-features = false }
 
 [features]
-default = ["digest"]
+default = ["std","digest"]
 alloc = ["elliptic-curve/alloc", "signature/alloc", "spki/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0"
 hex-literal = "0.4"
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
-sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "tamir/v1.3.0-rc2" }
+sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "secp256r1" }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -38,7 +38,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["dev"
 sha2 = { version = "0.10", default-features = false }
 
 [features]
-default = ["std","digest"]
+default = ["digest"]
 alloc = ["elliptic-curve/alloc", "signature/alloc", "spki/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+// #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -315,7 +315,6 @@ where
                 if prehash.len() == 32 && curve.is_some() {
                     let pubkey = Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap())?;
                     return VerifyingKey::from_sec1_bytes(&pubkey).map_err(|_| Error::new())
-                    // return Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap());
                 }
             }
         }

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -313,7 +313,9 @@ where
 
                 // Note: An additional check can be added to ensure the field bytes size is 32 bytes, but this is not neceessary.
                 if prehash.len() == 32 && curve.is_some() {
-                    return Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap());
+                    let pubkey = Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap());
+                    return VerifyingKey::from_sec1_bytes(&pubkey).map_err(|_| Error::new())
+                    // return Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap());
                 }
             }
         }

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -313,7 +313,7 @@ where
 
                 // Note: An additional check can be added to ensure the field bytes size is 32 bytes, but this is not neceessary.
                 if prehash.len() == 32 && curve.is_some() {
-                    let pubkey = Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap());
+                    let pubkey = Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap())?;
                     return VerifyingKey::from_sec1_bytes(&pubkey).map_err(|_| Error::new())
                     // return Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve.unwrap());
                 }

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -34,10 +34,14 @@ use {
     signature::digest::Digest,
 };
 
+
+
+
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
         use digest::generic_array::GenericArray;
         use elliptic_curve::Curve;
+        use crate::sp1::Secp256Curve;
     }
 }
 
@@ -285,24 +289,36 @@ where
     /// Recover a [`VerifyingKey`] from the given `prehash` of a message, the
     /// signature over that prehashed message, and a [`RecoveryId`].
     ///
-    /// This function has been modified to support SP1 acceleration for secp256k1 signature verification
-    /// in the context of a zkVM. If the curve is secp256k1 and the prehash is 32 bytes long (indicating a SHA-256 hash),
-    /// the function will use [`crate::sp1::VerifyingKey::recover_from_prehash_secp256k1`] to return a precomputed public key.
+    /// This function has been modified to support SP1 acceleration for secp256k1/r1 signature verification
+    /// in the context of a zkVM. If the curve is secp256k1 or secp256r1 and the prehash is 32 bytes long (indicating a SHA-256 hash),
+    /// the function will use [`crate::sp1::VerifyingKey::recover_from_prehash_secp256`] to return a precomputed public key.
     #[allow(non_snake_case)]
     pub fn recover_from_prehash(
         prehash: &[u8],
         signature: &Signature<C>,
         recovery_id: RecoveryId,
     ) -> Result<Self> {
-        // Only override the recovery function if this is a secp256k1 curve and the prehash is 32 bytes long (indicating a SHA-256 hash).
+        // Only override the recovery function if this is a secp256k1 or secp256r1 curve and the prehash is 32 bytes long (indicating a SHA-256 hash).
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
                 // Reference: https://en.bitcoin.it/wiki/Secp256k1.
                 const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+                const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
+
+                let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
+                    Secp256Curve::K1
+                } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
+                    Secp256Curve::R1
+                } else {
+                    return Err(Error::new()); // Unsupported curve
+                };
 
                 // Note: An additional check can be added to ensure the field bytes size is 32 bytes, but this is not neceessary.
-                if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) && prehash.len() == 32 {
-                    return Self::recover_from_prehash_secp256k1(prehash, signature, recovery_id);
+                // if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) && prehash.len() == 32 {
+                //     return Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve);
+                // }
+                if prehash.len() == 32 && (curve == Secp256Curve::K1 || curve == Secp256Curve::R1) {
+                    return Self::recover_from_prehash_secp256(prehash, signature, recovery_id, curve);
                 }
             }
         }

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -88,9 +88,8 @@ where
     ) -> Result<()> {
         let mut sig_bytes = [0u8; 64];
         sig_bytes.copy_from_slice(&signature.to_bytes());
-        let s_inv =
-            recover_s_inv_unconstrained(&sig_bytes);
-
+        let s_inv = recover_s_inv_unconstrained(&sig_bytes);
+        
         // Convert the s_inverse bytes to a scalar.
         let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv).unwrap()).unwrap();
         // let decompressed_pubkey = decompress_pubkey(pubkey, curve)?;

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -87,7 +87,7 @@ where
     ) -> Result<()> {
         let (r, s) = signature.split_scalars();
         let s_inv = *s.invert_vartime();
-        return verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+        return Self::verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
     }
 
 

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -79,16 +79,16 @@ where
     /// - `msg_hash`: The prehashed message to verify the signature against.
     /// - `signature`: The signature to verify.
     /// - `curve`: The curve to verify the signature against.
-    pub fn verify_prehash_secp256(
-        pubkey: &[u8; 65],
-        prehash: &[u8],
-        signature: &Signature<C>,
-        curve: Secp256Curve,
-    ) -> Result<()> {
-        let (r, s) = signature.split_scalars();
-        let s_inv = *s.invert_vartime();
-        return verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
-    }
+    // pub fn verify_prehash_secp256(
+    //     pubkey: &[u8; 65],
+    //     prehash: &[u8],
+    //     signature: &Signature<C>,
+    //     curve: Secp256Curve,
+    // ) -> Result<()> {
+    //     let (r, s) = signature.split_scalars();
+    //     let s_inv = *s.invert_vartime();
+    //     return verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+    // }
 
 
     /// Verify the prehashed message against the provided ECDSA signature.

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -132,14 +132,6 @@ where
                 x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
                 x_bytes_be.reverse();
                 x_bytes_be
-
-                // let x_field = bits2field::<C>(&x_bytes_be);
-                // if x_field.is_err() {
-                //     return false;
-                // }
-                // return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
-                // return verify_signature_with_curve::<Secp256k1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
-
             },
             Secp256Curve::R1 => {
                 let point = Secp256r1Point::multi_scalar_multiplication(
@@ -155,13 +147,6 @@ where
                 x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
                 x_bytes_be.reverse();
                 x_bytes_be
-
-                // let x_field = bits2field::<C>(&x_bytes_be);
-                // if x_field.is_err() {
-                //     return false;
-                // }
-                // return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
-                // return verify_signature_with_curve::<Secp256r1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
             },
         };
 

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -177,8 +177,8 @@ where
 impl<C> VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>: DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldBytesSize<C>: sec1::ModulusSize,
+    // AffinePoint<C>: DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    // FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Recover a [`VerifyingKey`] from the given `prehash` of a message, the

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -16,6 +16,7 @@ use sp1_lib::{
 
 use crate::{hazmat::bits2field, Signature, SignatureSize, VerifyingKey};
 
+#[derive(Debug, Clone, Copy)]
 pub enum Secp256Curve {
     K1, // secp256k1
     R1, // secp256r1

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -88,7 +88,12 @@ where
     ) -> Result<()> {
         let (r, s) = signature.split_scalars();
         let s_inv = *s.invert_vartime();
-        return Self::verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+        let verified = Self::verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+        if verified {
+            Ok(())
+        } else {
+            Err(Error::new())
+        }
     }
 
 

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -88,7 +88,7 @@ where
     ) -> Result<()> {
         let (r, s) = signature.split_scalars();
         let s_inv = *s.invert_vartime();
-        let decompressed_pubkey = decompress_pubkey(&pubkey, curve)?;
+        let decompressed_pubkey = decompress_pubkey(pubkey, curve)?;
         let verified = Self::verify_signature_secp256(&decompressed_pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
         if verified {
             Ok(())

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -88,7 +88,7 @@ where
     ) -> Result<()> {
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..64].copy_from_slice(&signature.to_bytes());
-        sig_bytes[64] = recovery_id.to_byte();
+        sig_bytes[64] = 0u8;
         let (_, s_inv) =
             recover_ecdsa_unconstrained(&sig_bytes, prehash.try_into().unwrap(), curve);
 

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -92,7 +92,6 @@ where
         
         // Convert the s_inverse bytes to a scalar.
         let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv).unwrap()).unwrap();
-        // let decompressed_pubkey = decompress_pubkey(pubkey, curve)?;
         let verified = Self::verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inverse, curve);
         if verified {
             Ok(())
@@ -227,6 +226,11 @@ fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32], curve: Secp2
     (recovered_compressed_pubkey, s_inv_bytes_le)
 }
 
+/// Outside of the VM, computes the s_inverse value from a signature.
+///
+/// WARNING: The values are read from outside of the VM and are not constrained to be correct. Use
+/// [`VerifyingKey::recover_from_prehash_secp256`] to securely recover the public key associated with
+/// a signature and message hash.
 fn recover_s_inv_unconstrained(sig: &[u8;64]) -> [u8; 32] {
     unconstrained! {
         io::write(R1_ECRECOVER_HOOK, sig);

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -79,16 +79,16 @@ where
     /// - `msg_hash`: The prehashed message to verify the signature against.
     /// - `signature`: The signature to verify.
     /// - `curve`: The curve to verify the signature against.
-    // pub fn verify_prehash_secp256(
-    //     pubkey: &[u8; 65],
-    //     prehash: &[u8],
-    //     signature: &Signature<C>,
-    //     curve: Secp256Curve,
-    // ) -> Result<()> {
-    //     let (r, s) = signature.split_scalars();
-    //     let s_inv = *s.invert_vartime();
-    //     return verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
-    // }
+    pub fn verify_prehash_secp256(
+        pubkey: &[u8; 65],
+        prehash: &[u8],
+        signature: &Signature<C>,
+        curve: Secp256Curve,
+    ) -> Result<()> {
+        let (r, s) = signature.split_scalars();
+        let s_inv = *s.invert_vartime();
+        return verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+    }
 
 
     /// Verify the prehashed message against the provided ECDSA signature.

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -119,48 +119,77 @@ where
         // Compute the MSM.
         match curve {
             Secp256Curve::K1 => {
-                let point = Secp256k1Point::multi_scalar_multiplication(
-                    &u1_le_bits,
-                    Secp256k1Point::new(Secp256k1Point::GENERATOR),
-                    &u2_le_bits,
-                    Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-                );
-                let p = point.unwrap();
+                // let point = Secp256k1Point::multi_scalar_multiplication(
+                //     &u1_le_bits,
+                //     Secp256k1Point::new(Secp256k1Point::GENERATOR),
+                //     &u2_le_bits,
+                //     Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+                // );
+                // let p = point.unwrap();
 
-                // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-                let mut x_bytes_be = [0u8; 32];
-                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
-                x_bytes_be.reverse();
+                // // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+                // let mut x_bytes_be = [0u8; 32];
+                // x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+                // x_bytes_be.reverse();
 
-                let x_field = bits2field::<C>(&x_bytes_be);
-                if x_field.is_err() {
-                    return false;
-                }
-                return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
+                // let x_field = bits2field::<C>(&x_bytes_be);
+                // if x_field.is_err() {
+                //     return false;
+                // }
+                // return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
+                return verify_signature_with_curve::<Secp256k1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
 
             },
             Secp256Curve::R1 => {
-                let point = Secp256r1Point::multi_scalar_multiplication(
-                    &u1_le_bits,
-                    Secp256r1Point::new(Secp256r1Point::GENERATOR),
-                    &u2_le_bits,
-                    Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-                );
-                let p = point.unwrap();
+                // let point = Secp256r1Point::multi_scalar_multiplication(
+                //     &u1_le_bits,
+                //     Secp256r1Point::new(Secp256r1Point::GENERATOR),
+                //     &u2_le_bits,
+                //     Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+                // );
+                // let p = point.unwrap();
 
-                // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-                let mut x_bytes_be = [0u8; 32];
-                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
-                x_bytes_be.reverse();
+                // // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+                // let mut x_bytes_be = [0u8; 32];
+                // x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+                // x_bytes_be.reverse();
 
-                let x_field = bits2field::<C>(&x_bytes_be);
-                if x_field.is_err() {
-                    return false;
-                }
-                return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
+                // let x_field = bits2field::<C>(&x_bytes_be);
+                // if x_field.is_err() {
+                //     return false;
+                // }
+                // return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
+                return verify_signature_with_curve::<Secp256r1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
             },
         };
     }
+}
+
+fn verify_signature_with_curve<P: CurveArithmetic>(
+    u1_le_bits: &[bool],
+    u2_le_bits: &[bool],
+    pubkey_x_le_bytes: &[u8],
+    pubkey_y_le_bytes: &[u8],
+    r: &Scalar<C>,
+) -> bool {
+    let point = P::multi_scalar_multiplication(
+        u1_le_bits,
+        P::new(P::GENERATOR),
+        u2_le_bits,
+        P::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+    );
+    let p = point.unwrap();
+
+    // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+    let mut x_bytes_be = [0u8; 32];
+    x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+    x_bytes_be.reverse();
+
+    let x_field = bits2field::<C>(&x_bytes_be);
+    if x_field.is_err() {
+        return false;
+    }
+    *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
 }
 
 /// Convert big-endian bytes with the most significant bit first to little-endian bytes with the least significant bit first.

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -82,7 +82,6 @@ where
     ///
     /// This function is a modified version of [`crate::hazmat::verify_prehashed`] with
     /// changes implemented to support SP1 acceleration.
-
     pub fn verify_signature_secp256(
         pubkey: &[u8; 65],
         msg_hash: &[u8; 32],
@@ -157,33 +156,6 @@ where
         return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
     }
 }
-
-// fn verify_signature_with_curve<P: CurveArithmetic>(
-//     u1_le_bits: &[bool],
-//     u2_le_bits: &[bool],
-//     pubkey_x_le_bytes: &[u8],
-//     pubkey_y_le_bytes: &[u8],
-//     r: &Scalar<C>,
-// ) -> bool {
-//     let point = P::multi_scalar_multiplication(
-//         u1_le_bits,
-//         P::new(P::GENERATOR),
-//         u2_le_bits,
-//         P::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-//     );
-//     let p = point.unwrap();
-
-//     // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-//     let mut x_bytes_be = [0u8; 32];
-//     x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
-//     x_bytes_be.reverse();
-
-//     let x_field = bits2field::<C>(&x_bytes_be);
-//     if x_field.is_err() {
-//         return false;
-//     }
-//     *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
-// }
 
 /// Convert big-endian bytes with the most significant bit first to little-endian bytes with the least significant bit first.
 fn be_bytes_to_le_bits(be_bytes: &[u8; 32]) -> [bool; 256] {

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -81,7 +81,7 @@ where
     /// - `signature`: The signature to verify.
     /// - `curve`: The curve to verify the signature against.
     pub fn verify_prehash_secp256(
-        pubkey: &[u8; 65],
+        pubkey: &[u8; 33],
         prehash: &[u8],
         signature: &Signature<C>,
         curve: Secp256Curve,

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -31,14 +31,15 @@ where
     /// Recover a [`VerifyingKey`] from the given `prehash` of a message, the
     /// signature over that prehashed message, and a [`RecoveryId`].
     ///
-    /// This function leverages SP1 syscalls for secp256k1 to accelerate public key recovery
+    /// This function leverages SP1 syscalls for secp256k1 and secp256r1 to accelerate public key recovery
     /// in the zkVM. Verifies the signature against the recovered public key to ensure correctness.
+    /// If the signature is valid, returns the public key in uncompressed form (big-endian).
     pub fn recover_from_prehash_secp256(
         prehash: &[u8],
         signature: &Signature<C>,
         recovery_id: RecoveryId,
         curve: Secp256Curve,
-    ) -> Result<[u8; 65]> { //Result<Self>
+    ) -> Result<[u8; 65]> { 
         // Recover the compressed public key and s_inverse value from the signature and prehashed message.
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..64].copy_from_slice(&signature.to_bytes());

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -2,6 +2,7 @@ use crate::{Error, RecoveryId, Result};
 use digest::generic_array::ArrayLength;
 use elliptic_curve::PrimeField;
 use elliptic_curve::{
+    ops::Invert,
     point::DecompressPoint,
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, Scalar,

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -36,7 +36,7 @@ where
         signature: &Signature<C>,
         recovery_id: RecoveryId,
         curve: Secp256Curve,
-    ) -> Result<> {
+    ) -> Result<()> {
         // Recover the compressed public key and s_inverse value from the signature and prehashed message.
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..64].copy_from_slice(&signature.to_bytes());
@@ -52,7 +52,7 @@ where
 
         // Verify the signature against the recovered public key. The last byte of the signature
         // is the recovery id, which is not used in the verification process.
-        let verified = Self::verify_signature_secp256(
+        let verified = Self::verify_signature_secp256_less_traits(
             &pubkey,
             &prehash.try_into().unwrap(),
             &signature,
@@ -66,6 +66,80 @@ where
         } else {
             Err(Error::new())
         }
+    }
+
+    /// Verify the prehashed message against the provided ECDSA signature.
+    ///
+    /// Accepts the following arguments:
+    /// - `pubkey`: The public key to verify the signature against. The public key is in uncompressed form. The points
+    /// are represented as big-endian bytes and need to be converted to little endian to instantiate the Secp256k1Point.
+    /// - `msg_hash`: The prehashed message to verify the signature against.
+    /// - `signature`: The signature to verify.
+    /// - `s_inverse`: The inverse of the scalar `s` in the signature.
+    ///
+    /// This function is a modified version of [`crate::hazmat::verify_prehashed`] with
+    /// changes implemented to support SP1 acceleration.
+
+    pub fn verify_signature_secp256_less_traits(
+        pubkey: &[u8; 65],
+        msg_hash: &[u8; 32],
+        signature: &Signature<C>,
+        s_inverse: &Scalar<C>,
+        curve: Secp256Curve,
+    ) -> bool {
+        let mut pubkey_x_le_bytes = pubkey[1..33].to_vec();
+        pubkey_x_le_bytes.reverse();
+        let mut pubkey_y_le_bytes = pubkey[33..].to_vec();
+        pubkey_y_le_bytes.reverse();
+
+        // Split the signature into its two scalars.
+        let (r, s) = signature.split_scalars();
+        assert_eq!(*s_inverse * s.as_ref(), Scalar::<C>::ONE);
+
+        // Convert the message hash into a scalar.
+        let field = bits2field::<C>(msg_hash);
+        if field.is_err() {
+            return false;
+        }
+        let field: Scalar<C> = Scalar::<C>::from_repr(field.unwrap()).unwrap();
+        let z = field;
+
+        // Compute the two scalars.
+        let u1 = z * s_inverse;
+        let u2 = *r * s_inverse;
+
+        // Convert u1 and u2 to "little-endian" bits (LSb first with little-endian byte order) for the MSM.
+        let (u1_be_bytes, u2_be_bytes) = (u1.to_repr(), u2.to_repr());
+        let u1_le_bits = be_bytes_to_le_bits(u1_be_bytes.as_slice().try_into().unwrap());
+        let u2_le_bits = be_bytes_to_le_bits(u2_be_bytes.as_slice().try_into().unwrap());
+
+        // Compute the MSM.
+        let res = match curve {
+            Secp256Curve::K1 => Secp256k1Point::multi_scalar_multiplication(
+                &u1_le_bits,
+                Secp256k1Point::new(Secp256k1Point::GENERATOR),
+                &u2_le_bits,
+                Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+            ),
+            Secp256Curve::R1 => Secp256r1Point::multi_scalar_multiplication(
+                &u1_le_bits,
+                Secp256r1Point::new(Secp256r1Point::GENERATOR),
+                &u2_le_bits,
+                Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+            ),
+        }
+        .unwrap();
+
+        // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+        let mut x_bytes_be = [0u8; 32];
+        x_bytes_be[..32].copy_from_slice(&res.to_le_bytes()[..32]);
+        x_bytes_be.reverse();
+
+        let x_field = bits2field::<C>(&x_bytes_be);
+        if x_field.is_err() {
+            return false;
+        }
+        *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
     }
 
 }

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -117,80 +117,88 @@ where
         let u2_le_bits = be_bytes_to_le_bits(u2_be_bytes.as_slice().try_into().unwrap());
 
         // Compute the MSM.
-        match curve {
+        let x_bytes_be = match curve {
             Secp256Curve::K1 => {
-                // let point = Secp256k1Point::multi_scalar_multiplication(
-                //     &u1_le_bits,
-                //     Secp256k1Point::new(Secp256k1Point::GENERATOR),
-                //     &u2_le_bits,
-                //     Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-                // );
-                // let p = point.unwrap();
+                let point = Secp256k1Point::multi_scalar_multiplication(
+                    &u1_le_bits,
+                    Secp256k1Point::new(Secp256k1Point::GENERATOR),
+                    &u2_le_bits,
+                    Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+                );
+                let p = point.unwrap();
 
-                // // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-                // let mut x_bytes_be = [0u8; 32];
-                // x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
-                // x_bytes_be.reverse();
+                // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+                let mut x_bytes_be = [0u8; 32];
+                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+                x_bytes_be.reverse();
+                return x_bytes_be;
 
                 // let x_field = bits2field::<C>(&x_bytes_be);
                 // if x_field.is_err() {
                 //     return false;
                 // }
                 // return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
-                return verify_signature_with_curve::<Secp256k1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
+                // return verify_signature_with_curve::<Secp256k1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
 
             },
             Secp256Curve::R1 => {
-                // let point = Secp256r1Point::multi_scalar_multiplication(
-                //     &u1_le_bits,
-                //     Secp256r1Point::new(Secp256r1Point::GENERATOR),
-                //     &u2_le_bits,
-                //     Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-                // );
-                // let p = point.unwrap();
+                let point = Secp256r1Point::multi_scalar_multiplication(
+                    &u1_le_bits,
+                    Secp256r1Point::new(Secp256r1Point::GENERATOR),
+                    &u2_le_bits,
+                    Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+                );
+                let p = point.unwrap();
 
-                // // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-                // let mut x_bytes_be = [0u8; 32];
-                // x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
-                // x_bytes_be.reverse();
+                // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+                let mut x_bytes_be = [0u8; 32];
+                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+                x_bytes_be.reverse();
+                return x_bytes_be;
 
                 // let x_field = bits2field::<C>(&x_bytes_be);
                 // if x_field.is_err() {
                 //     return false;
                 // }
                 // return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
-                return verify_signature_with_curve::<Secp256r1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
+                // return verify_signature_with_curve::<Secp256r1Point>(&u1_le_bits, &u2_le_bits, &pubkey_x_le_bytes, &pubkey_y_le_bytes, r);
             },
         };
+
+        let x_field = bits2field::<C>(&x_bytes_be);
+        if x_field.is_err() {
+            return false;
+        }
+        return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
     }
 }
 
-fn verify_signature_with_curve<P: CurveArithmetic>(
-    u1_le_bits: &[bool],
-    u2_le_bits: &[bool],
-    pubkey_x_le_bytes: &[u8],
-    pubkey_y_le_bytes: &[u8],
-    r: &Scalar<C>,
-) -> bool {
-    let point = P::multi_scalar_multiplication(
-        u1_le_bits,
-        P::new(P::GENERATOR),
-        u2_le_bits,
-        P::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-    );
-    let p = point.unwrap();
+// fn verify_signature_with_curve<P: CurveArithmetic>(
+//     u1_le_bits: &[bool],
+//     u2_le_bits: &[bool],
+//     pubkey_x_le_bytes: &[u8],
+//     pubkey_y_le_bytes: &[u8],
+//     r: &Scalar<C>,
+// ) -> bool {
+//     let point = P::multi_scalar_multiplication(
+//         u1_le_bits,
+//         P::new(P::GENERATOR),
+//         u2_le_bits,
+//         P::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+//     );
+//     let p = point.unwrap();
 
-    // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-    let mut x_bytes_be = [0u8; 32];
-    x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
-    x_bytes_be.reverse();
+//     // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+//     let mut x_bytes_be = [0u8; 32];
+//     x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+//     x_bytes_be.reverse();
 
-    let x_field = bits2field::<C>(&x_bytes_be);
-    if x_field.is_err() {
-        return false;
-    }
-    *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
-}
+//     let x_field = bits2field::<C>(&x_bytes_be);
+//     if x_field.is_err() {
+//         return false;
+//     }
+//     *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
+// }
 
 /// Convert big-endian bytes with the most significant bit first to little-endian bytes with the least significant bit first.
 fn be_bytes_to_le_bits(be_bytes: &[u8; 32]) -> [bool; 256] {

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -126,7 +126,7 @@ where
 
                 // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
                 let mut x_bytes_be = [0u8; 32];
-                x_bytes_be[..32].copy_from_slice(&res.to_le_bytes()[..32]);
+                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
                 x_bytes_be.reverse();
 
                 let x_field = bits2field::<C>(&x_bytes_be);
@@ -147,7 +147,7 @@ where
 
                 // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
                 let mut x_bytes_be = [0u8; 32];
-                x_bytes_be[..32].copy_from_slice(&res.to_le_bytes()[..32]);
+                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
                 x_bytes_be.reverse();
 
                 let x_field = bits2field::<C>(&x_bytes_be);
@@ -269,32 +269,49 @@ where
         let u2_le_bits = be_bytes_to_le_bits(u2_be_bytes.as_slice().try_into().unwrap());
 
         // Compute the MSM.
-        let res = match curve {
-            Secp256Curve::K1 => Secp256k1Point::multi_scalar_multiplication(
-                &u1_le_bits,
-                Secp256k1Point::new(Secp256k1Point::GENERATOR),
-                &u2_le_bits,
-                Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-            ),
-            Secp256Curve::R1 => Secp256r1Point::multi_scalar_multiplication(
-                &u1_le_bits,
-                Secp256r1Point::new(Secp256r1Point::GENERATOR),
-                &u2_le_bits,
-                Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
-            ),
-        }
-        .unwrap();
+        match curve {
+            Secp256Curve::K1 => {
+                let point = Secp256k1Point::multi_scalar_multiplication(
+                    &u1_le_bits,
+                    Secp256k1Point::new(Secp256k1Point::GENERATOR),
+                    &u2_le_bits,
+                    Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+                );
+                let p = point.unwrap();
 
-        // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
-        let mut x_bytes_be = [0u8; 32];
-        x_bytes_be[..32].copy_from_slice(&res.to_le_bytes()[..32]);
-        x_bytes_be.reverse();
+                // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+                let mut x_bytes_be = [0u8; 32];
+                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+                x_bytes_be.reverse();
 
-        let x_field = bits2field::<C>(&x_bytes_be);
-        if x_field.is_err() {
-            return false;
-        }
-        *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap()
+                let x_field = bits2field::<C>(&x_bytes_be);
+                if x_field.is_err() {
+                    return false;
+                }
+                return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
+
+            },
+            Secp256Curve::R1 => {
+                let point = Secp256r1Point::multi_scalar_multiplication(
+                    &u1_le_bits,
+                    Secp256r1Point::new(Secp256r1Point::GENERATOR),
+                    &u2_le_bits,
+                    Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+                );
+                let p = point.unwrap();
+
+                // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
+                let mut x_bytes_be = [0u8; 32];
+                x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
+                x_bytes_be.reverse();
+
+                let x_field = bits2field::<C>(&x_bytes_be);
+                if x_field.is_err() {
+                    return false;
+                }
+                return *r == Scalar::<C>::from_repr(x_field.unwrap()).unwrap();
+            },
+        };
     }
 }
 

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -230,7 +230,7 @@ fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32], curve: Secp2
 
 fn recover_s_inv_unconstrained(sig: &[u8;64]) -> [u8; 32] {
     unconstrained! {
-        io::write(K1_ECRECOVER_HOOK, sig);
+        io::write(R1_ECRECOVER_HOOK, sig);
     }
     let s_inv_bytes_le: [u8; 32] = io::read_vec().try_into().unwrap();
     s_inv_bytes_le

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -191,7 +191,7 @@ where
         signature: &Signature<C>,
         recovery_id: RecoveryId,
         curve: Secp256Curve,
-    ) -> Result<Self> {
+    ) -> Result<[u8; 65]> { //Result<Self>
         // Recover the compressed public key and s_inverse value from the signature and prehashed message.
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..64].copy_from_slice(&signature.to_bytes());
@@ -217,7 +217,8 @@ where
 
         // If the signature is valid, return the public key.
         if verified {
-            VerifyingKey::from_sec1_bytes(&pubkey).map_err(|_| Error::new())
+            // VerifyingKey::from_sec1_bytes(&pubkey).map_err(|_| Error::new())
+            Ok(pubkey)
         } else {
             Err(Error::new())
         }

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -16,7 +16,7 @@ use sp1_lib::{
 
 use crate::{hazmat::bits2field, Signature, SignatureSize, VerifyingKey};
 
-enum Secp256Curve {
+pub enum Secp256Curve {
     K1, // secp256k1
     R1, // secp256r1
 }

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -86,9 +86,10 @@ where
         signature: &Signature<C>,
         curve: Secp256Curve,
     ) -> Result<()> {
-
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes.copy_from_slice(&signature.to_bytes());
         let s_inv =
-            recover_s_inv_unconstrained(&signature.to_bytes());
+            recover_s_inv_unconstrained(&sig_bytes);
 
         // Convert the s_inverse bytes to a scalar.
         let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv).unwrap()).unwrap();

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -131,7 +131,7 @@ where
                 let mut x_bytes_be = [0u8; 32];
                 x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
                 x_bytes_be.reverse();
-                return x_bytes_be;
+                x_bytes_be
 
                 // let x_field = bits2field::<C>(&x_bytes_be);
                 // if x_field.is_err() {
@@ -154,7 +154,7 @@ where
                 let mut x_bytes_be = [0u8; 32];
                 x_bytes_be[..32].copy_from_slice(&p.to_le_bytes()[..32]);
                 x_bytes_be.reverse();
-                return x_bytes_be;
+                x_bytes_be
 
                 // let x_field = bits2field::<C>(&x_bytes_be);
                 // if x_field.is_err() {

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -71,6 +71,25 @@ where
         }
     }
 
+    /// Verify the prehashed message against the provided ECDSA signature using SP1 acceleration.
+    /// (essentially the same as verify_signature_secp256, but only takes in signature and finds inverse of s)
+    /// Accepts the following arguments:
+    /// - `pubkey`: The public key to verify the signature against. The public key is in uncompressed form. The points
+    /// are represented as big-endian bytes and need to be converted to little endian to instantiate the Secp256k1Point.
+    /// - `msg_hash`: The prehashed message to verify the signature against.
+    /// - `signature`: The signature to verify.
+    /// - `curve`: The curve to verify the signature against.
+    pub fn verify_prehash_secp256(
+        pubkey: &[u8; 65],
+        prehash: &[u8],
+        signature: &Signature<C>,
+        curve: Secp256Curve,
+    ) -> Result<()> {
+        let (r, s) = signature.split_scalars();
+        let s_inv = *s.invert_vartime();
+        return verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+    }
+
 
     /// Verify the prehashed message against the provided ECDSA signature.
     ///

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -81,15 +81,15 @@ where
     /// - `signature`: The signature to verify.
     /// - `curve`: The curve to verify the signature against.
     pub fn verify_prehash_secp256(
-        pubkey: &[u8; 33],
+        pubkey: &[u8; 65],
         prehash: &[u8],
         signature: &Signature<C>,
         curve: Secp256Curve,
     ) -> Result<()> {
         let (r, s) = signature.split_scalars();
         let s_inv = *s.invert_vartime();
-        let decompressed_pubkey = decompress_pubkey(pubkey, curve)?;
-        let verified = Self::verify_signature_secp256(&decompressed_pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+        // let decompressed_pubkey = decompress_pubkey(pubkey, curve)?;
+        let verified = Self::verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
         if verified {
             Ok(())
         } else {

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -88,7 +88,8 @@ where
     ) -> Result<()> {
         let (r, s) = signature.split_scalars();
         let s_inv = *s.invert_vartime();
-        let verified = Self::verify_signature_secp256(pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
+        let decompressed_pubkey = decompress_pubkey(&pubkey, curve)?;
+        let verified = Self::verify_signature_secp256(&decompressed_pubkey, prehash.try_into().unwrap(), signature, &s_inv, curve);
         if verified {
             Ok(())
         } else {

--- a/ecdsa/src/sp1.rs
+++ b/ecdsa/src/sp1.rs
@@ -8,13 +8,18 @@ use elliptic_curve::{
 };
 
 use elliptic_curve::Field;
-use sp1_lib::io::{self, FD_ECRECOVER_HOOK};
+use sp1_lib::io::{self, K1_ECRECOVER_HOOK, R1_ECRECOVER_HOOK};
 use sp1_lib::unconstrained;
 use sp1_lib::{
-    secp256k1::Secp256k1Point, syscall_secp256k1_decompress, utils::AffinePoint as Sp1AffinePoint,
+    secp256k1::Secp256k1Point, secp256r1::Secp256r1Point, syscall_secp256k1_decompress, syscall_secp256r1_decompress, utils::AffinePoint as Sp1AffinePoint,
 };
 
 use crate::{hazmat::bits2field, Signature, SignatureSize, VerifyingKey};
+
+enum Secp256Curve {
+    K1, // secp256k1
+    R1, // secp256r1
+}
 
 #[cfg(feature = "verifying")]
 impl<C> VerifyingKey<C>
@@ -29,31 +34,34 @@ where
     ///
     /// This function leverages SP1 syscalls for secp256k1 to accelerate public key recovery
     /// in the zkVM. Verifies the signature against the recovered public key to ensure correctness.
-    pub fn recover_from_prehash_secp256k1(
+
+    pub fn recover_from_prehash_secp256(
         prehash: &[u8],
         signature: &Signature<C>,
         recovery_id: RecoveryId,
+        curve: Secp256Curve,
     ) -> Result<Self> {
         // Recover the compressed public key and s_inverse value from the signature and prehashed message.
         let mut sig_bytes = [0u8; 65];
         sig_bytes[..64].copy_from_slice(&signature.to_bytes());
         sig_bytes[64] = recovery_id.to_byte();
         let (compressed_pubkey, s_inv) =
-            recover_ecdsa_unconstrained(&sig_bytes, prehash.try_into().unwrap());
+            recover_ecdsa_unconstrained(&sig_bytes, prehash.try_into().unwrap(), curve);
 
         // Convert the s_inverse bytes to a scalar.
         let s_inverse = Scalar::<C>::from_repr(bits2field::<C>(&s_inv).unwrap()).unwrap();
 
         // Transform the compressed public key into uncompressed form.
-        let pubkey = decompress_pubkey(&compressed_pubkey)?;
+        let pubkey = decompress_pubkey(&compressed_pubkey, curve)?;
 
         // Verify the signature against the recovered public key. The last byte of the signature
         // is the recovery id, which is not used in the verification process.
-        let verified = Self::verify_signature_secp256k1(
+        let verified = Self::verify_signature_secp256(
             &pubkey,
             &prehash.try_into().unwrap(),
             &signature,
             &s_inverse,
+            curve,
         );
 
         // If the signature is valid, return the public key.
@@ -75,18 +83,22 @@ where
     ///
     /// This function is a modified version of [`crate::hazmat::verify_prehashed`] with
     /// changes implemented to support SP1 acceleration.
-    pub fn verify_signature_secp256k1(
+
+    pub fn verify_signature_secp256(
         pubkey: &[u8; 65],
         msg_hash: &[u8; 32],
         signature: &Signature<C>,
         s_inverse: &Scalar<C>,
+        curve: Secp256Curve,
     ) -> bool {
         let mut pubkey_x_le_bytes = pubkey[1..33].to_vec();
         pubkey_x_le_bytes.reverse();
         let mut pubkey_y_le_bytes = pubkey[33..].to_vec();
         pubkey_y_le_bytes.reverse();
-        let affine =
-            Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat());
+        let affine = match curve {
+            Secp256Curve::K1 => Secp256k1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+            Secp256Curve::R1 => Secp256r1Point::from_le_bytes(&[pubkey_x_le_bytes, pubkey_y_le_bytes].concat()),
+        };
 
         // Split the signature into its two scalars.
         let (r, s) = signature.split_scalars();
@@ -110,12 +122,20 @@ where
         let u2_le_bits = be_bytes_to_le_bits(u2_be_bytes.as_slice().try_into().unwrap());
 
         // Compute the MSM.
-        let res = Secp256k1Point::multi_scalar_multiplication(
-            &u1_le_bits,
-            Secp256k1Point::new(Secp256k1Point::GENERATOR),
-            &u2_le_bits,
-            affine,
-        )
+        let res = match curve {
+            Secp256Curve::K1 => Secp256k1Point::multi_scalar_multiplication(
+                &u1_le_bits,
+                Secp256k1Point::new(Secp256k1Point::GENERATOR),
+                &u2_le_bits,
+                affine,
+            ),
+            Secp256Curve::R1 => Secp256r1Point::multi_scalar_multiplication(
+                &u1_le_bits,
+                Secp256r1Point::new(Secp256r1Point::GENERATOR),
+                &u2_le_bits,
+                affine,
+            ),
+        }
         .unwrap();
 
         // Convert the result of the MSM into a scalar and confirm that it matches the R value of the signature.
@@ -147,9 +167,9 @@ fn be_bytes_to_le_bits(be_bytes: &[u8; 32]) -> [bool; 256] {
 /// Outside of the VM, computes the pubkey and s_inverse value from a signature and a message hash.
 ///
 /// WARNING: The values are read from outside of the VM and are not constrained to be correct. Use
-/// [`VerifyingKey::recover_from_prehash_secp256k1`] to securely recover the public key associated with
+/// [`VerifyingKey::recover_from_prehash_secp256`] to securely recover the public key associated with
 /// a signature and message hash.
-fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32]) -> ([u8; 33], [u8; 32]) {
+fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32], curve: Secp256Curve) -> ([u8; 33], [u8; 32]) {
     // The `unconstrained!` wrapper is used to not include the cycles used to get the "hint" for the compressed
     // public key and s_inverse values from a non-zkVM context, because the values will be constrained
     // in the VM.
@@ -158,7 +178,10 @@ fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32]) -> ([u8; 33]
         let (buf_sig, buf_msg_hash) = buf.split_at_mut(sig.len());
         buf_sig.copy_from_slice(sig);
         buf_msg_hash.copy_from_slice(msg_hash);
-        io::write(FD_ECRECOVER_HOOK, &buf);
+        match curve {
+            Secp256Curve::K1 => io::write(K1_ECRECOVER_HOOK, &buf),
+            Secp256Curve::R1 => io::write(R1_ECRECOVER_HOOK, &buf),
+        }
     }
 
     let recovered_compressed_pubkey: [u8; 33] = io::read_vec().try_into().unwrap();
@@ -175,11 +198,11 @@ fn recover_ecdsa_unconstrained(sig: &[u8; 65], msg_hash: &[u8; 32]) -> ([u8; 33]
 /// The decompressed public key is 65 bytes long, with 0x04 as the first byte,
 /// and the remaining 64 bytes being the x and y coordinates of the decompressed pubkey in big-endian.
 ///
-/// More details on secp256k1 public key format can be found in the [Bitcoin wiki](https://en.bitcoin.it/wiki/Protocol_documentation#Signatures).
+/// More details on secp256k1/r1 public key format can be found in the [Bitcoin wiki](https://en.bitcoin.it/wiki/Protocol_documentation#Signatures).
 ///
 /// SAFETY: Our syscall will check that the x and y coordinates are within the
-/// secp256k1 scalar field.
-fn decompress_pubkey(compressed_pubkey: &[u8; 33]) -> Result<[u8; 65]> {
+/// secp256k1/r1 scalar field.
+fn decompress_pubkey(compressed_pubkey: &[u8; 33], curve: Secp256Curve) -> Result<[u8; 65]> {
     let mut decompressed_key: [u8; 64] = [0; 64];
     decompressed_key[..32].copy_from_slice(&compressed_pubkey[1..]);
     let is_odd = match compressed_pubkey[0] {
@@ -188,7 +211,10 @@ fn decompress_pubkey(compressed_pubkey: &[u8; 33]) -> Result<[u8; 65]> {
         _ => unreachable!("The first byte of the compressed public key must be 0x02 or 0x03."),
     };
     unsafe {
-        syscall_secp256k1_decompress(&mut decompressed_key, is_odd);
+        match curve {
+            Secp256Curve::K1 => syscall_secp256k1_decompress(&mut decompressed_key, is_odd),
+            Secp256Curve::R1 => syscall_secp256r1_decompress(&mut decompressed_key, is_odd),
+        }
     }
 
     let mut uncompressed_pubkey: [u8; 65] = [0; 65];

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -208,7 +208,7 @@ cfg_if::cfg_if! {
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
 
-                            let point = self.inner.to_encoded_point(true);
+                            let point = self.inner.to_encoded_point(false);
                             let pubkey = point.as_bytes();
                             let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
                             Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -189,20 +189,20 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                // Reference: https://en.bitcoin.it/wiki/Secp256k1.
-                const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
-                // Reference: https://neuromancer.sk/std/secg/secp256r1.
-                const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
+                // // Reference: https://en.bitcoin.it/wiki/Secp256k1.
+                // const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+                // // Reference: https://neuromancer.sk/std/secg/secp256r1.
+                // const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
-                let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
-                    Some(Secp256Curve::K1)
-                } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
-                    Some(Secp256Curve::R1)
-                } else {
-                    None
-                };
+                // let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
+                //     Some(Secp256Curve::K1)
+                // } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
+                //     Some(Secp256Curve::R1)
+                // } else {
+                //     None
+                // };
 
-                Self::recover_from_prehash_secp256(prehash, &sig, recid, curve.unwrap())?;
+                Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                 return Ok(());
             }
             

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -180,7 +180,9 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                return Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
+                // return Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
+                Self::recover_from_prehash(prehash, sig, recid)?;
+                return Ok(());
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -193,12 +193,12 @@ impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
         SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                PrehashVerifier::<Signature<C>>::verify_prehash(self, &msg_digest.finalize_fixed(), signature)?;
-                return Ok(());
-            }
-        }
+        // cfg_if::cfg_if! {
+        //     if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+        //         PrehashVerifier::<Signature<C>>::verify_prehash(self, &msg_digest.finalize_fixed(), signature)?;
+        //         return Ok(());
+        //     }
+        // }
         self.inner.as_affine().verify_digest(msg_digest, signature)
     }
 }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -54,11 +54,12 @@ cfg_if::cfg_if! {
         use digest::generic_array::GenericArray;
         use elliptic_curve::Curve;
         use crate::sp1::Secp256Curve;
+
+        #[cfg(feature = "std")]
+        use std::println;
     }
 }
 
-#[cfg(feature = "std")]
-use std::println;
 
 /// ECDSA public key used for verifying signatures. Generic over prime order
 /// elliptic curves (e.g. NIST P-curves)

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -191,19 +191,15 @@ impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
             DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
         SignatureSize<C>: ArrayLength<u8>,
-{   
-    cfg_if::cfg_if! {
-        if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-            fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
+{
+    fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
+        cfg_if::cfg_if! {
+            if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
                 PrehashVerifier::<Signature<C>>::verify_prehash(self, &msg_digest.finalize_fixed(), signature)?;
                 return Ok(());
             }
         }
-        else {
-            fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
-                self.inner.as_affine().verify_digest(msg_digest, signature)
-            }
-        }
+        self.inner.as_affine().verify_digest(msg_digest, signature)
     }
 }
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -208,9 +208,9 @@ cfg_if::cfg_if! {
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
 
-                            let point = self.inner.to_encoded_point(false);
+                            let point = self.inner.to_encoded_point(true);
                             let pubkey = point.as_bytes();
-                            let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
+                            let pubkey_array: &[u8; 33] = pubkey.try_into().unwrap();
                             Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;
                             return Ok(());
                         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -151,31 +151,55 @@ where
 // `*Verifier` trait impls
 //
 
-cfg_if::cfg_if! {   
-    if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-        impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
-        where
-            C: PrimeCurve + CurveArithmetic,
-            D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
-            AffinePoint<C>:
-                DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-            FieldBytesSize<C>: sec1::ModulusSize,
-            SignatureSize<C>: ArrayLength<u8>,
-        {
+// cfg_if::cfg_if! {   
+//     if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+//         impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
+//         where
+//             C: PrimeCurve + CurveArithmetic,
+//             D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+//             AffinePoint<C>:
+//                 DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+//             FieldBytesSize<C>: sec1::ModulusSize,
+//             SignatureSize<C>: ArrayLength<u8>,
+//         {
+//             fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
+//                 PrehashVerifier::<Signature<C>>::verify_prehash(self, &msg_digest.finalize_fixed(), signature)?;
+//                 return Ok(());
+//             }
+//         }
+//     }
+//     else {
+//         impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
+//         where
+//             C: PrimeCurve + CurveArithmetic,
+//             D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+//             AffinePoint<C>: VerifyPrimitive<C>,
+//             SignatureSize<C>: ArrayLength<u8>,
+//         {
+//             fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
+//                 self.inner.as_affine().verify_digest(msg_digest, signature)
+//             }
+//         }
+//     }
+// }
+
+impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
+    where
+        C: PrimeCurve + CurveArithmetic,
+        D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+        AffinePoint<C>:
+            DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+        FieldBytesSize<C>: sec1::ModulusSize,
+        SignatureSize<C>: ArrayLength<u8>,
+{   
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
             fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
                 PrehashVerifier::<Signature<C>>::verify_prehash(self, &msg_digest.finalize_fixed(), signature)?;
                 return Ok(());
             }
         }
-    }
-    else {
-        impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
-        where
-            C: PrimeCurve + CurveArithmetic,
-            D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
-            AffinePoint<C>: VerifyPrimitive<C>,
-            SignatureSize<C>: ArrayLength<u8>,
-        {
+        else {
             fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
                 self.inner.as_affine().verify_digest(msg_digest, signature)
             }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -161,7 +161,7 @@ where
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                self.verify_prehash(&msg_digest.finalize_fixed(), signature)?;
+                Self::verify_prehash(&msg_digest.finalize_fixed(), signature)?;
                 return Ok(());
             }
             
@@ -173,9 +173,7 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>:
-        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-    FieldBytesSize<C>: sec1::ModulusSize,
+    AffinePoint<C>: VerifyPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -170,50 +170,71 @@ where
     }
 }
 
-impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
-where
-    C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-{
-    fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                // Provides signature, recovery id, and prehash to call recover_from_prehash_secp256 (our generic recover function for secp256k1 and secp256r1)
-                // which passes iff verify_signature_secp256k1 returns true
-                // let mut sig = signature.clone();
-                // let mut recid = 0u8;
-                // if let Some(sig_normalized) = sig.normalize_s() {
-                //     sig = sig_normalized;
-                //     recid ^= 1;
-                // }
-                // let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
-                // let recid = RecoveryId::trial_recovery_from_prehash(self, prehash, &sig).unwrap();
-                // Reference: https://en.bitcoin.it/wiki/Secp256k1.
-                // const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
-                // // Reference: https://neuromancer.sk/std/secg/secp256r1.
-                // const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
+cfg_if::cfg_if! {
+    if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+        impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
+            where
+                C: PrimeCurve + CurveArithmetic,
+                AffinePoint<C>:
+                    DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+                FieldBytesSize<C>: sec1::ModulusSize,
+                SignatureSize<C>: ArrayLength<u8>,
+            {
+                fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
+                    cfg_if::cfg_if! {
+                        if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+                            // Provides signature, recovery id, and prehash to call recover_from_prehash_secp256 (our generic recover function for secp256k1 and secp256r1)
+                            // which passes iff verify_signature_secp256k1 returns true
+                            // let mut sig = signature.clone();
+                            // let mut recid = 0u8;
+                            // if let Some(sig_normalized) = sig.normalize_s() {
+                            //     sig = sig_normalized;
+                            //     recid ^= 1;
+                            // }
+                            // let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+                            // let recid = RecoveryId::trial_recovery_from_prehash(self, prehash, &sig).unwrap();
+                            // Reference: https://en.bitcoin.it/wiki/Secp256k1.
+                            const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+                            // Reference: https://neuromancer.sk/std/secg/secp256r1.
+                            const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
-                // let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
-                //     Some(Secp256Curve::K1)
-                // } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
-                //     Some(Secp256Curve::R1)
-                // } else {
-                //     None
-                // };
-                // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
-                // return Ok(());
+                            let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
+                                Some(Secp256Curve::K1)
+                            } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
+                                Some(Secp256Curve::R1)
+                            } else {
+                                None
+                            };
+                            // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
+                            // return Ok(());
 
-                let pubkey = self.inner.to_sec1_bytes();
-                Self::verify_prehash_secp256(&pubkey, prehash, signature, Secp256Curve::R1)?;
-                return Ok(());
-            }
-            
+                            let pubkey = self.inner.to_encoded_point(true).as_bytes();
+                            Self::verify_prehash_secp256(&pubkey, prehash, signature, curve)?;
+                            return Ok(());
+                        }
+                        
+                    }
+                    let field = bits2field::<C>(prehash)?;
+                    self.inner.as_affine().verify_prehashed(&field, signature)
+                }
         }
-        let field = bits2field::<C>(prehash)?;
-        self.inner.as_affine().verify_prehashed(&field, signature)
+    }
+    else {
+        impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
+            where
+                C: PrimeCurve + CurveArithmetic,
+                AffinePoint<C>: VerifyPrimitive<C>,
+                SignatureSize<C>: ArrayLength<u8>,
+            {
+                fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
+                    let field = bits2field::<C>(prehash)?;
+                    self.inner.as_affine().verify_prehashed(&field, signature)
+                }
+            }
+
     }
 }
+
 
 impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -8,7 +8,7 @@ use crate::RecoveryId;
 use core::{cmp::Ordering, fmt::Debug};
 use elliptic_curve::{
     generic_array::ArrayLength,
-    point::PointCompression,
+    point::{PointCompression, DecompressPoint},
     sec1::{self, CompressedPoint, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey,
 };
@@ -182,7 +182,7 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                return recovery::<impl VerifyingKey<C>>::recover_from_prehash(prehash, &sig, recid).map(|_| ()).map_err(|_| Error::new());
+                return Self::recover_from_prehash(prehash, &sig, recid).map(|_| ()).map_err(|_| Error::new());
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -180,7 +180,7 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                return Self::recover_from_prehash(prehash, &sig, recid).map(|_| ()).map_err(|_| Error::new());
+                return Self::recover_from_prehash_secp256_less_traits(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -180,7 +180,6 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                // return Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
                 Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                 return Ok(());
             }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -202,7 +202,7 @@ where
                     None
                 };
 
-                Self::recover_from_prehash_secp256(prehash, &sig, recid, curve)?;
+                Self::recover_from_prehash_secp256(prehash, &sig, recid, curve.unwrap())?;
                 return Ok(());
             }
             

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -161,7 +161,7 @@ where
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                Self::verify_prehash(&msg_digest.finalize_fixed(), signature)?;
+                Self::verify_prehash(self,&msg_digest.finalize_fixed(), signature)?;
                 return Ok(());
             }
             

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -159,13 +159,13 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                self.verify_prehash(&msg_digest.finalize_fixed(), signature)?;
-                return Ok(());
-            }
+        // cfg_if::cfg_if! {
+        //     if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+        //         self.verify_prehash(&msg_digest.finalize_fixed(), signature)?;
+        //         return Ok(());
+        //     }
             
-        }
+        // }
         self.inner.as_affine().verify_digest(msg_digest, signature)
     }
 }
@@ -209,7 +209,8 @@ cfg_if::cfg_if! {
                             // return Ok(());
 
                             let pubkey = self.inner.to_encoded_point(true).as_bytes();
-                            Self::verify_prehash_secp256(pubkey, prehash, signature, curve)?;
+                            let pubkey_array: &[u8; 65] = pubkey.try_into().map_err(|_| Error::new()).unwrap();
+                            Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve)?;
                             return Ok(());
                         }
                         

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -166,8 +166,7 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>: VerifyPrimitive<C> + DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldBytesSize<C>: sec1::ModulusSize,
+    AffinePoint<C>: VerifyPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
@@ -181,7 +180,7 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                return Self::recover_from_prehash(prehash, &sig, recid).map(|_| ()).map_err(|_| Error::new());
+                return recovery::<impl VerifyingKey<C>>::recover_from_prehash(prehash, &sig, recid).map(|_| ()).map_err(|_| Error::new());
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -57,6 +57,9 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(feature = "std")]
+use std::println;
+
 /// ECDSA public key used for verifying signatures. Generic over prime order
 /// elliptic curves (e.g. NIST P-curves)
 ///
@@ -172,6 +175,7 @@ where
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+                println!("cycle-tracker-report-start: normalize_s");
                 let mut sig = signature.clone();
                 let mut recid = 0u8;
                 if let Some(sig_normalized) = sig.normalize_s() {
@@ -179,6 +183,7 @@ where
                     recid ^= 1;
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+                println!("cycle-tracker-report-end: normalize_s");
 
                 Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                 return Ok(());

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -181,31 +181,29 @@ where
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
                 // Provides signature, recovery id, and prehash to call recover_from_prehash_secp256 (our generic recover function for secp256k1 and secp256r1)
                 // which passes iff verify_signature_secp256k1 returns true
-                // let mut sig = signature.clone();
-                // let mut recid = 0u8;
-                // if let Some(sig_normalized) = sig.normalize_s() {
-                //     sig = sig_normalized;
-                //     recid ^= 1;
-                // }
-                // let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+                let mut sig = signature.clone();
+                let mut recid = 0u8;
+                if let Some(sig_normalized) = sig.normalize_s() {
+                    sig = sig_normalized;
+                    recid ^= 1;
+                }
+                let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
                 // let recid = RecoveryId::trial_recovery_from_prehash(self, prehash, &sig).unwrap();
                 // Reference: https://en.bitcoin.it/wiki/Secp256k1.
-                const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
-                // Reference: https://neuromancer.sk/std/secg/secp256r1.
-                const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
+                // const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+                // // Reference: https://neuromancer.sk/std/secg/secp256r1.
+                // const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
-                let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
-                    Some(Secp256Curve::K1)
-                } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
-                    Some(Secp256Curve::R1)
-                } else {
-                    None
-                };
-                // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
-                // return Ok(());
-                let pubkey = self.inner.as_affine().to_encoded_point(false).to_bytes();
-                Self::verify_prehash_secp256(&pubkey, prehash, signature, curve)?;
+                // let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
+                //     Some(Secp256Curve::K1)
+                // } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
+                //     Some(Secp256Curve::R1)
+                // } else {
+                //     None
+                // };
+                Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                 return Ok(());
+                
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -209,7 +209,7 @@ cfg_if::cfg_if! {
                             // return Ok(());
 
                             let pubkey = self.inner.to_encoded_point(true).as_bytes();
-                            Self::verify_prehash_secp256(&pubkey, prehash, signature, curve)?;
+                            Self::verify_prehash_secp256(pubkey, prehash, signature, curve)?;
                             return Ok(());
                         }
                         

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -181,13 +181,13 @@ where
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
                 // Provides signature, recovery id, and prehash to call recover_from_prehash_secp256 (our generic recover function for secp256k1 and secp256r1)
                 // which passes iff verify_signature_secp256k1 returns true
-                let mut sig = signature.clone();
-                let mut recid = 0u8;
-                if let Some(sig_normalized) = sig.normalize_s() {
-                    sig = sig_normalized;
-                    recid ^= 1;
-                }
-                let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+                // let mut sig = signature.clone();
+                // let mut recid = 0u8;
+                // if let Some(sig_normalized) = sig.normalize_s() {
+                //     sig = sig_normalized;
+                //     recid ^= 1;
+                // }
+                // let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
                 // let recid = RecoveryId::trial_recovery_from_prehash(self, prehash, &sig).unwrap();
                 // Reference: https://en.bitcoin.it/wiki/Secp256k1.
                 // const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
@@ -201,9 +201,12 @@ where
                 // } else {
                 //     None
                 // };
-                Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
+                // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
+                // return Ok(());
+
+                let pubkey = self.inner.to_sec1_bytes();
+                Self::verify_prehash_secp256(&pubkey, prehash, signature, Secp256Curve::R1)?;
                 return Ok(());
-                
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -238,32 +238,15 @@ cfg_if::cfg_if! {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-        impl<C, D> Verifier<Signature<C>> for VerifyingKey<C>
-        where
-            C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-            AffinePoint<C>:
-                DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-            FieldBytesSize<C>: sec1::ModulusSize,
-            SignatureSize<C>: ArrayLength<u8>,
-        {
-            fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
-                DigestVerifier::<D, Signature<C>>::verify_digest(self, C::Digest::new_with_prefix(msg), signature)
-            }
-        }
-    }
-    else {
-        impl<C> Verifier<Signature<C>> for VerifyingKey<C>
-        where
-            C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-            AffinePoint<C>: VerifyPrimitive<C>,
-            SignatureSize<C>: ArrayLength<u8>,
-        {
-            fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
-                DigestVerifier::<D, Signature<C>>::verify_digest(self, C::Digest::new_with_prefix(msg), signature)
-            }
-        }
+
+impl<C> Verifier<Signature<C>> for VerifyingKey<C>
+where
+    C: PrimeCurve + CurveArithmetic + DigestPrimitive,
+    AffinePoint<C>: VerifyPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
+        self.verify_digest(C::Digest::new_with_prefix(msg), signature)
     }
 }
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -173,7 +173,9 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>: VerifyPrimitive<C>,
+    AffinePoint<C>:
+        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -151,25 +151,6 @@ where
 // `*Verifier` trait impls
 //
 
-impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
-where
-    C: PrimeCurve + CurveArithmetic,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
-    AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-{
-    fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                self.verify_prehash(&msg_digest.finalize_fixed(), signature)?;
-                return Ok(());
-            }
-            
-        }
-        self.inner.as_affine().verify_digest(msg_digest, signature)
-    }
-}
-
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
         impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
@@ -221,6 +202,25 @@ cfg_if::cfg_if! {
                 }
             }
 
+    }
+}
+
+impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
+where
+    C: PrimeCurve + CurveArithmetic,
+    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    AffinePoint<C>: VerifyPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
+        cfg_if::cfg_if! {
+            if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+                self.verify_prehash(&msg_digest.finalize_fixed(), signature)?;
+                return Ok(());
+            }
+            
+        }
+        self.inner.as_affine().verify_digest(msg_digest, signature)
     }
 }
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -181,28 +181,30 @@ where
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
                 // Provides signature, recovery id, and prehash to call recover_from_prehash_secp256 (our generic recover function for secp256k1 and secp256r1)
                 // which passes iff verify_signature_secp256k1 returns true
-                let mut sig = signature.clone();
-                let mut recid = 1u8;
-                if let Some(sig_normalized) = sig.normalize_s() {
-                    sig = sig_normalized;
-                    recid ^= 1;
-                }
-                let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+                // let mut sig = signature.clone();
+                // let mut recid = 0u8;
+                // if let Some(sig_normalized) = sig.normalize_s() {
+                //     sig = sig_normalized;
+                //     recid ^= 1;
+                // }
+                // let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+                // let recid = RecoveryId::trial_recovery_from_prehash(self, prehash, &sig).unwrap();
+                // Reference: https://en.bitcoin.it/wiki/Secp256k1.
+                const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+                // Reference: https://neuromancer.sk/std/secg/secp256r1.
+                const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
-                // // Reference: https://en.bitcoin.it/wiki/Secp256k1.
-                // const SECP256K1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
-                // // Reference: https://neuromancer.sk/std/secg/secp256r1.
-                // const SECP256R1_ORDER: [u8; 32] = hex_literal::hex!("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
-
-                // let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
-                //     Some(Secp256Curve::K1)
-                // } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
-                //     Some(Secp256Curve::R1)
-                // } else {
-                //     None
-                // };
-
-                Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
+                let curve = if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256K1_ORDER)) {
+                    Some(Secp256Curve::K1)
+                } else if C::ORDER == <C as Curve>::Uint::decode_field_bytes(GenericArray::from_slice(&SECP256R1_ORDER)) {
+                    Some(Secp256Curve::R1)
+                } else {
+                    None
+                };
+                // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
+                // return Ok(());
+                let pubkey = self.inner.as_affine().to_encoded_point(false).to_bytes();
+                Self::verify_prehash_secp256(&pubkey, prehash, signature, curve)?;
                 return Ok(());
             }
             

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -184,13 +184,11 @@ where
 // }
 
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
-    where
-        C: PrimeCurve + CurveArithmetic,
-        D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
-        AffinePoint<C>:
-            DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-        FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArrayLength<u8>,
+where
+    C: PrimeCurve + CurveArithmetic,
+    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    AffinePoint<C>: VerifyPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
         // cfg_if::cfg_if! {

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -208,9 +208,9 @@ cfg_if::cfg_if! {
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
 
-                            let point = self.inner.to_encoded_point(true);
+                            let point = self.inner.to_encoded_point(false);
                             let pubkey = point.as_bytes();
-                            let pubkey_array: &[u8; 33] = pubkey.try_into().unwrap();
+                            let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
                             Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;
                             return Ok(());
                         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -166,7 +166,9 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>: VerifyPrimitive<C>,
+    AffinePoint<C>:
+        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -10,7 +10,7 @@ use elliptic_curve::{
     generic_array::ArrayLength,
     point::{PointCompression, DecompressPoint},
     sec1::{self, CompressedPoint, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
-    AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey,
+    AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey, FieldBytesEncoding,
 };
 use signature::{
     digest::{Digest, FixedOutput},
@@ -161,7 +161,7 @@ where
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                Self::verify_prehash(self,&msg_digest.finalize_fixed(), signature)?;
+                self.verify_prehash(&msg_digest.finalize_fixed(), signature)?;
                 return Ok(());
             }
             

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -180,7 +180,7 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                return Self::recover_from_prehash_secp256_less_traits(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
+                return Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -166,9 +166,7 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>:
-        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
-    FieldBytesSize<C>: sec1::ModulusSize,
+    AffinePoint<C>: VerifyPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -331,7 +331,9 @@ where
 impl<C> Verifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    AffinePoint<C>: VerifyPrimitive<C>,
+    AffinePoint<C>:
+        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
     der::MaxSize<C>: ArrayLength<u8>,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -251,7 +251,9 @@ where
 impl<C> Verifier<SignatureWithOid<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    AffinePoint<C>: VerifyPrimitive<C>,
+    AffinePoint<C>:
+        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify(&self, msg: &[u8], sig: &SignatureWithOid<C>) -> Result<()> {
@@ -285,7 +287,9 @@ where
 impl<C> PrehashVerifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    AffinePoint<C>: VerifyPrimitive<C>,
+    AffinePoint<C>:
+        DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
     der::MaxSize<C>: ArrayLength<u8>,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -4,6 +4,7 @@ use crate::{
     hazmat::{bits2field, DigestPrimitive, VerifyPrimitive},
     Error, Result, Signature, SignatureSize,
 };
+use crate::RecoveryId;
 use core::{cmp::Ordering, fmt::Debug};
 use elliptic_curve::{
     generic_array::ArrayLength,
@@ -165,7 +166,8 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    AffinePoint<C>: VerifyPrimitive<C>,
+    AffinePoint<C>: VerifyPrimitive<C> + DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
@@ -179,7 +181,7 @@ where
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
-                return Self::recover_from_prehash(prehash, sig, recid).map(|_| ()).map_err(|_| Error::new());
+                return Self::recover_from_prehash(prehash, &sig, recid).map(|_| ()).map_err(|_| Error::new());
             }
             
         }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -173,7 +173,6 @@ where
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
-                println!("cycle-tracker-report-start: normalize_s");
                 let mut sig = signature.clone();
                 let mut recid = 0u8;
                 if let Some(sig_normalized) = sig.normalize_s() {
@@ -181,7 +180,6 @@ where
                     recid ^= 1;
                 }
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
-                println!("cycle-tracker-report-end: normalize_s");
 
                 Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                 return Ok(());

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -208,7 +208,7 @@ cfg_if::cfg_if! {
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
 
-                            let point = self.inner.to_encoded_point(false);
+                            let point = self.inner.to_encoded_point(true);
                             let pubkey = point.as_bytes();
                             let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
                             Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -54,9 +54,6 @@ cfg_if::cfg_if! {
         use digest::generic_array::GenericArray;
         use elliptic_curve::Curve;
         use crate::sp1::Secp256Curve;
-
-        #[cfg(feature = "std")]
-        use std::println;
     }
 }
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -8,7 +8,6 @@ use crate::RecoveryId;
 use core::{cmp::Ordering, fmt::Debug};
 use elliptic_curve::{
     generic_array::ArrayLength,
-    ops::Invert,
     point::{PointCompression, DecompressPoint},
     sec1::{self, CompressedPoint, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey, FieldBytesEncoding,
@@ -209,7 +208,8 @@ cfg_if::cfg_if! {
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
 
-                            let pubkey = self.inner.to_encoded_point(false).as_bytes();
+                            let point = self.inner.to_encoded_point(false);
+                            let pubkey = point.as_bytes();
                             let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
                             Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;
                             return Ok(());

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -238,15 +238,32 @@ cfg_if::cfg_if! {
     }
 }
 
-
-impl<C> Verifier<Signature<C>> for VerifyingKey<C>
-where
-    C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-{
-    fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
-        self.verify_digest(C::Digest::new_with_prefix(msg), signature)
+cfg_if::cfg_if! {
+    if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+        impl<C, D> Verifier<Signature<C>> for VerifyingKey<C>
+        where
+            C: PrimeCurve + CurveArithmetic + DigestPrimitive,
+            AffinePoint<C>:
+                DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
+            FieldBytesSize<C>: sec1::ModulusSize,
+            SignatureSize<C>: ArrayLength<u8>,
+        {
+            fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
+                DigestVerifier::<D, Signature<C>>::verify_digest(self, C::Digest::new_with_prefix(msg), signature)
+            }
+        }
+    }
+    else {
+        impl<C> Verifier<Signature<C>> for VerifyingKey<C>
+        where
+            C: PrimeCurve + CurveArithmetic + DigestPrimitive,
+            AffinePoint<C>: VerifyPrimitive<C>,
+            SignatureSize<C>: ArrayLength<u8>,
+        {
+            fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
+                DigestVerifier::<D, Signature<C>>::verify_digest(self, C::Digest::new_with_prefix(msg), signature)
+            }
+        }
     }
 }
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -57,7 +57,6 @@ cfg_if::cfg_if! {
     }
 }
 
-
 /// ECDSA public key used for verifying signatures. Generic over prime order
 /// elliptic curves (e.g. NIST P-curves)
 ///
@@ -173,6 +172,8 @@ where
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
+                // Provides signature, recovery id, and prehash to call recover_from_prehash_secp256 (our generic recover function for secp256k1 and secp256r1)
+                // which passes iff verify_signature_secp256k1 returns true
                 let mut sig = signature.clone();
                 let mut recid = 0u8;
                 if let Some(sig_normalized) = sig.normalize_s() {

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -181,7 +181,7 @@ where
                 let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
 
                 // return Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1).map(|_| ()).map_err(|_| Error::new());
-                Self::recover_from_prehash(prehash, sig, recid)?;
+                Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                 return Ok(());
             }
             

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -1,4 +1,10 @@
 //! ECDSA verifying: checking signatures are authentic using a [`VerifyingKey`].
+//!
+//! # ⚠️ Warning: our patching can cause issues for users who want to use VerifyingKey on curves that don't 
+//!  implement the traits: 
+//!     AffinePoint<C>:
+//!     DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
+//!     FieldBytesSize<C>: sec1::ModulusSize,
 
 use crate::{
     hazmat::{bits2field, DigestPrimitive, VerifyPrimitive},

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -207,11 +207,14 @@ cfg_if::cfg_if! {
                             };
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
-
+                            println!("cycle-tracker-start: to_encoded_point");
                             let point = self.inner.to_encoded_point(false);
+                            println!("cycle-tracker-end: to_encoded_point");
                             let pubkey = point.as_bytes();
                             let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
+                            println!("cycle-tracker-start: verify_prehash_secp256");
                             Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;
+                            println!("cycle-tracker-end: verify_prehash_secp256");
                             return Ok(());
                         }
                         

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -8,6 +8,7 @@ use crate::RecoveryId;
 use core::{cmp::Ordering, fmt::Debug};
 use elliptic_curve::{
     generic_array::ArrayLength,
+    ops::Invert,
     point::{PointCompression, DecompressPoint},
     sec1::{self, CompressedPoint, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey, FieldBytesEncoding,
@@ -208,9 +209,9 @@ cfg_if::cfg_if! {
                             // Self::recover_from_prehash_secp256(prehash, &sig, recid, Secp256Curve::R1)?;
                             // return Ok(());
 
-                            let pubkey = self.inner.to_encoded_point(true).as_bytes();
-                            let pubkey_array: &[u8; 65] = pubkey.try_into().map_err(|_| Error::new()).unwrap();
-                            Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve)?;
+                            let pubkey = self.inner.to_encoded_point(false).as_bytes();
+                            let pubkey_array: &[u8; 65] = pubkey.try_into().unwrap();
+                            Self::verify_prehash_secp256(pubkey_array, prehash, signature, curve.unwrap())?;
                             return Ok(());
                         }
                         


### PR DESCRIPTION
**Warning:** our patching can cause issues for users who want to use VerifyingKey on curves that don't 
implement the traits: 
 AffinePoint<C>: DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
 FieldBytesSize<C>: sec1::ModulusSize,